### PR TITLE
Finished MotivateAndExplainRGB and MotivateAndExplainYCbCr

### DIFF
--- a/JPEGImageCompression/classes.py
+++ b/JPEGImageCompression/classes.py
@@ -189,3 +189,184 @@ class PixelArray(VGroup):
             return VGroup(*list(self.dict.values())[value])
         else:
             return self.dict[value]
+
+
+string_to_mob_map = {}
+
+
+class RDecimalNumber(DecimalNumber):
+    def set_submobjects_from_number(self, number):
+        self.number = number
+        self.submobjects = []
+
+        num_string = self.get_num_string(number)
+        self.add(*(map(self.string_to_mob, num_string)))
+
+        # Add non-numerical bits
+        if self.show_ellipsis:
+            self.add(
+                self.string_to_mob("\\dots", Text, color=self.color),
+            )
+
+        if self.unit is not None:
+            self.unit_sign = self.string_to_mob(self.unit, Text)
+            self.add(self.unit_sign)
+
+        self.arrange(
+            buff=self.digit_buff_per_font_unit * self._font_size,
+            aligned_edge=DOWN,
+        )
+
+        # Handle alignment of parts that should be aligned
+        # to the bottom
+        for i, c in enumerate(num_string):
+            if c == "-" and len(num_string) > i + 1:
+                self[i].align_to(self[i + 1], UP)
+                self[i].shift(self[i + 1].height * DOWN / 2)
+            elif c == ",":
+                self[i].shift(self[i].height * DOWN / 2)
+        if self.unit and self.unit.startswith("^"):
+            self.unit_sign.align_to(self, UP)
+
+        # track the initial height to enable scaling via font_size
+        self.initial_height = self.height
+
+        if self.include_background_rectangle:
+            self.add_background_rectangle()
+
+    def string_to_mob(self, string, mob_class=Text, **kwargs):
+        if string not in string_to_mob_map:
+            string_to_mob_map[string] = mob_class(
+                string, font_size=1.0, font="SF Mono", **kwargs
+            )
+        mob = string_to_mob_map[string].copy()
+        mob.font_size = self._font_size
+        return mob
+
+
+class RVariable(VMobject):
+    """A class for displaying text that continuously updates to reflect the value of a python variable.
+
+    Automatically adds the text for the label and the value when instantiated and added to the screen.
+
+    Parameters
+    ----------
+    var : Union[:class:`int`, :class:`float`]
+        The python variable you need to keep track of and display.
+    label : Union[:class:`str`, :class:`~.Tex`, :class:`~.MathTex`, :class:`~.Text`, :class:`~.TexSymbol`, :class:`~.SingleStringMathTex`]
+        The label for your variable, for example ``x = ...``. To use math mode, for e.g.
+        subscripts, superscripts, etc. simply pass in a raw string.
+    var_type : Union[:class:`DecimalNumber`, :class:`Integer`], optional
+        The class used for displaying the number. Defaults to :class:`DecimalNumber`.
+    num_decimal_places : :class:`int`, optional
+        The number of decimal places to display in your variable. Defaults to 2.
+        If `var_type` is an :class:`Integer`, this parameter is ignored.
+    kwargs : Any
+            Other arguments to be passed to `~.Mobject`.
+
+    Attributes
+    ----------
+    label : Union[:class:`str`, :class:`~.Tex`, :class:`~.MathTex`, :class:`~.Text`, :class:`~.TexSymbol`, :class:`~.SingleStringMathTex`]
+        The label for your variable, for example ``x = ...``.
+    tracker : :class:`~.ValueTracker`
+        Useful in updating the value of your variable on-screen.
+    value : Union[:class:`DecimalNumber`, :class:`Integer`]
+        The tex for the value of your variable.
+
+    Examples
+    --------
+    Normal usage::
+
+        # DecimalNumber type
+        var = 0.5
+        on_screen_var = Variable(var, Text("var"), num_decimal_places=3)
+        # Integer type
+        int_var = 0
+        on_screen_int_var = Variable(int_var, Text("int_var"), var_type=Integer)
+        # Using math mode for the label
+        on_screen_int_var = Variable(int_var, "{a}_{i}", var_type=Integer)
+
+    .. manim:: VariablesWithValueTracker
+
+        class VariablesWithValueTracker(Scene):
+            def construct(self):
+                var = 0.5
+                on_screen_var = Variable(var, Text("var"), num_decimal_places=3)
+
+                # You can also change the colours for the label and value
+                on_screen_var.label.set_color(RED)
+                on_screen_var.value.set_color(GREEN)
+
+                self.play(Write(on_screen_var))
+                # The above line will just display the variable with
+                # its initial value on the screen. If you also wish to
+                # update it, you can do so by accessing the `tracker` attribute
+                self.wait()
+                var_tracker = on_screen_var.tracker
+                var = 10.5
+                self.play(var_tracker.animate.set_value(var))
+                self.wait()
+
+                int_var = 0
+                on_screen_int_var = Variable(
+                    int_var, Text("int_var"), var_type=Integer
+                ).next_to(on_screen_var, DOWN)
+                on_screen_int_var.label.set_color(RED)
+                on_screen_int_var.value.set_color(GREEN)
+
+                self.play(Write(on_screen_int_var))
+                self.wait()
+                var_tracker = on_screen_int_var.tracker
+                var = 10.5
+                self.play(var_tracker.animate.set_value(var))
+                self.wait()
+
+                # If you wish to have a somewhat more complicated label for your
+                # variable with subscripts, superscripts, etc. the default class
+                # for the label is MathTex
+                subscript_label_var = 10
+                on_screen_subscript_var = Variable(subscript_label_var, "{a}_{i}").next_to(
+                    on_screen_int_var, DOWN
+                )
+                self.play(Write(on_screen_subscript_var))
+                self.wait()
+
+    .. manim:: VariableExample
+
+        class VariableExample(Scene):
+            def construct(self):
+                start = 2.0
+
+                x_var = Variable(start, 'x', num_decimal_places=3)
+                sqr_var = Variable(start**2, 'x^2', num_decimal_places=3)
+                Group(x_var, sqr_var).arrange(DOWN)
+
+                sqr_var.add_updater(lambda v: v.tracker.set_value(x_var.tracker.get_value()**2))
+
+                self.add(x_var, sqr_var)
+                self.play(x_var.tracker.animate.set_value(5), run_time=2, rate_func=linear)
+                self.wait(0.1)
+
+    """
+
+    def __init__(
+        self, var, label, var_type=RDecimalNumber, num_decimal_places=2, **kwargs
+    ):
+
+        self.label = Text(label, font="SF Mono") if isinstance(label, str) else label
+        equals = Text("=").next_to(self.label, RIGHT)
+        self.label.add(equals)
+
+        self.tracker = ValueTracker(var)
+
+        self.value = RDecimalNumber(
+            self.tracker.get_value(), num_decimal_places=num_decimal_places
+        )
+
+        self.value.add_updater(lambda v: v.set_value(self.tracker.get_value())).next_to(
+            self.label,
+            RIGHT,
+        )
+
+        super().__init__(**kwargs)
+        self.add(self.label, self.value)

--- a/JPEGImageCompression/functions.py
+++ b/JPEGImageCompression/functions.py
@@ -159,10 +159,35 @@ def rgb2ycbcr(r, g, b):  # in (0,255) range
     return y, cb, cr
 
 
+def rgb2ycbcr4map(c: list):
+    y = 0.299 * c[0] + 0.587 * c[1] + 0.114 * c[2]
+    cb = 128 - 0.168736 * c[0] - 0.331364 * c[1] + 0.5 * c[2]
+    cr = 128 + 0.5 * c[0] - 0.418688 * c[1] - 0.081312 * c[2]
+    return y, cb, cr
+
+
+# R = Y + 1.4075 * (V - 128)
+# G = Y - 0.3455 * (U - 128) - (0.7169 * (V - 128))
+# B = Y + 1.7790 * (U - 128)
 def ycbcr2rgb(y, cb, cr):
-    r = y + 1.402 * (cr - 128)
+    r = y + 1.4075 * (cr - 128)
     g = y - 0.34414 * (cb - 128) - 0.71414 * (cr - 128)
-    b = y + 1.772 * (cb - 128)
+    b = y + 1.7790 * (cb - 128)
+
+    r = np.clip(r, 0, 255)
+    g = np.clip(g, 0, 255)
+    b = np.clip(b, 0, 255)
+    return r, g, b
+
+
+def ycbcr2rgb4map(c: list):
+    r = c[0] + 1.4075 * (c[2] - 128)
+    g = c[0] - 0.34414 * (c[1] - 128) - 0.71414 * (c[2] - 128)
+    b = c[0] + 1.7790 * (c[1] - 128)
+
+    r = np.clip(r, 0, 255)
+    g = np.clip(g, 0, 255)
+    b = np.clip(b, 0, 255)
     return r, g, b
 
 

--- a/JPEGImageCompression/scenes.py
+++ b/JPEGImageCompression/scenes.py
@@ -782,22 +782,20 @@ class ShowConfusingImage(Scene):
 class MotivateAndExplainYCbCr(ThreeDScene):
     def construct(self):
         self.set_camera_orientation(phi=75 * DEGREES, theta=-45 * DEGREES)
-        # self.begin_ambient_camera_rotation(rate=1)
+        self.begin_ambient_camera_rotation(rate=1)
         self.move_camera(zoom=0.2)
 
         color_resolution = 4
         cubes_rgb = self.create_color_space_cube(
             coords2rgbcolor, color_res=color_resolution, cube_side_length=1
-        )
+        ).move_to(ORIGIN)
         cubes_yuv = self.create_color_space_cube(
             coords2ycbcrcolor, color_res=color_resolution, cube_side_length=1
         )
         self.wait()
 
-        self.add(
-            cubes_rgb,
-        )
-        self.wait(2)
+        self.play(FadeIn(cubes_rgb))
+        self.wait(6)
 
         anim_group = []
         # this loop removes every cube that is not in the grayscale diagonal of the RGB colorspace.
@@ -807,7 +805,6 @@ class MotivateAndExplainYCbCr(ThreeDScene):
             coords = index2coords(index, base=color_resolution)
             if not coords[0] == coords[1] == coords[2]:
                 anim_group.append(FadeOut(cube))
-                cubes_rgb.remove(cube)
 
         self.play(*anim_group)
 
@@ -815,7 +812,7 @@ class MotivateAndExplainYCbCr(ThreeDScene):
         # cubes_arranged = cubes_rgb.copy().arrange(OUT, buff=0)
         # self.play(Transform(cubes_rgb, cubes_arranged))
 
-        self.wait(4)
+        self.wait(6)
 
         # cubes_yuv.move_to(cubes_arranged.get_center())
 
@@ -866,9 +863,9 @@ class MotivateAndExplainYCbCr(ThreeDScene):
 
                     color = color_space_func(i_discrete, j_discrete, k_discrete)
 
-                    curr_cube = Cube(
-                        side_length=side_length, fill_color=color, fill_opacity=1
-                    ).shift((LEFT * i + UP * j + OUT * k) * offset)
+                    curr_cube = Cube(fill_color=color, fill_opacity=1).shift(
+                        (LEFT * i + UP * j + OUT * k) * offset
+                    )
 
                     cubes.append(curr_cube)
 

--- a/JPEGImageCompression/scenes.py
+++ b/JPEGImageCompression/scenes.py
@@ -5,6 +5,8 @@ File to define all the different scenes our video will be composed of.
 from math import sqrt
 from manim import *
 import cv2
+from itertools import product
+from pprint import pprint
 
 from functions import *
 from classes import *
@@ -781,20 +783,27 @@ class ShowConfusingImage(Scene):
 
 class MotivateAndExplainYCbCr(ThreeDScene):
     def construct(self):
+        self.yuv_plane_animation()
+
+    def yuv_plane_animation(self):
+        color_plane = self.create_yuv_plane(y=127, color_res=128)
+
+        self.add(color_plane)
+
+    def color_cube_animation(self):
         self.set_camera_orientation(phi=75 * DEGREES, theta=-45 * DEGREES)
         self.begin_ambient_camera_rotation(rate=1)
-        self.move_camera(zoom=0.2)
+        self.move_camera(zoom=0.8)
 
         color_resolution = 4
         cubes_rgb = self.create_color_space_cube(
             coords2rgbcolor, color_res=color_resolution, cube_side_length=1
         ).move_to(ORIGIN)
-        cubes_yuv = self.create_color_space_cube(
-            coords2ycbcrcolor, color_res=color_resolution, cube_side_length=1
-        )
+
         self.wait()
 
         self.play(FadeIn(cubes_rgb))
+
         self.wait(6)
 
         anim_group = []
@@ -808,19 +817,7 @@ class MotivateAndExplainYCbCr(ThreeDScene):
 
         self.play(*anim_group)
 
-        # self.play(Rotate(cubes_rgb, angle=PI * 2))
-        # cubes_arranged = cubes_rgb.copy().arrange(OUT, buff=0)
-        # self.play(Transform(cubes_rgb, cubes_arranged))
-
         self.wait(6)
-
-        # cubes_yuv.move_to(cubes_arranged.get_center())
-
-        # this is a very bad way of transforming the grayscale line to
-        # the cube obviously but it illustrates the point at least for now
-        # self.play(Transform(cubes_arranged, cubes_yuv))
-        # self.play(Rotate(cubes_arranged, angle=PI * 2))
-        # self.wait(4)
 
     def create_color_space_cube(
         self,
@@ -872,6 +869,23 @@ class MotivateAndExplainYCbCr(ThreeDScene):
         cubes_rgb = Group(*cubes)
 
         return cubes_rgb
+
+    def create_yuv_plane(self, y=127, color_res=64):
+        color_plane_data = [
+            [y, u * (256 // color_res), v * (256 // color_res)]
+            for u in range(color_res)
+            for v in range(color_res)
+        ]
+
+        rgb_conv = np.array(
+            [ycbcr2rgb4map(c) for c in color_plane_data], dtype=np.uint8
+        ).reshape((color_res, color_res, 3))
+
+        mob = ImageMobject(rgb_conv)
+        mob.set_resampling_algorithm(RESAMPLING_ALGORITHMS["linear"])
+        mob.scale_to_fit_width(4)
+
+        return mob
 
 
 class ImageUtils(Scene):

--- a/JPEGImageCompression/scenes.py
+++ b/JPEGImageCompression/scenes.py
@@ -783,21 +783,46 @@ class ShowConfusingImage(Scene):
 
 
 class MotivateAndExplainRGB(ThreeDScene):
+    def construct(self):
+        self.color_cube_animation()
+
     def color_cube_animation(self):
         self.set_camera_orientation(phi=75 * DEGREES, theta=-45 * DEGREES)
-        self.begin_ambient_camera_rotation(rate=1)
+        self.begin_ambient_camera_rotation(rate=0.4)
         self.move_camera(zoom=0.5)
 
-        # change this value to 8 or 16. 8 is pretty slow already, we may not need
-        # that much resolution for this small demo.
-        color_resolution = 3
+        title = (
+            Text("RGB color space", font="CMU Serif", weight=BOLD)
+            .scale(0.9)
+            .to_edge(UP, buff=0.6)
+        )
 
-        cubes_rgb = self.create_color_space_cube(
-            coords2rgbcolor, color_res=color_resolution, cube_side_length=0.8
-        ).move_to(ORIGIN)
-        cubes_rgb_expanded = self.create_color_space_cube(
-            coords2rgbcolor, color_res=color_resolution, cube_side_length=0.8, buff=0.6
-        ).move_to(ORIGIN)
+        self.add_fixed_in_frame_mobjects(title)
+        self.wait(3)
+
+        # change this value to 8 or 16 for the final renders.
+        # 8 is pretty slow already, we may not need
+        # that much resolution for this small explanation.
+        color_resolution = 8
+
+        cubes_rgb = (
+            self.create_color_space_cube(
+                coords2rgbcolor, color_res=color_resolution, cube_side_length=0.8
+            )
+            .scale_to_fit_height(5)
+            .move_to(ORIGIN)
+        )
+
+        cubes_rgb_expanded = (
+            self.create_color_space_cube(
+                coords2rgbcolor,
+                color_res=color_resolution,
+                cube_side_length=0.8,
+                buff=0.2,
+            )
+            .scale_to_fit_height(5)
+            .move_to(ORIGIN)
+        )
 
         self.wait()
 

--- a/JPEGImageCompression/scenes.py
+++ b/JPEGImageCompression/scenes.py
@@ -910,22 +910,46 @@ class MotivateAndExplainYCbCr(Scene):
 
         # YCbCr stands for Y, Chroma Blue and Chroma Red.
 
-        self.play(LaggedStartMap(FadeIn, ycbcr_vg, lag_ratio=0.5))
+        self.play(
+            LaggedStartMap(FadeIn, ycbcr_vg, lag_ratio=0.5),
+        )
+
         self.wait()
         self.play(
-            FadeTransformPieces(
-                ycbcr_vg,
-                ycbcr_vg_vert,
-                stretch=False,
-                # key_map={ycbcr_vg[-1][-2]: ycbcr_vg_vert[-1][6]},
-            )
+            # Y
+            Transform(
+                ycbcr_vg[0],
+                ycbcr_vg_vert[0],
+            ),
+            # C to chroma
+            Transform(
+                ycbcr_vg[1][0],
+                ycbcr_vg_vert[1][:6],
+            ),
+            # b to blue
+            Transform(
+                ycbcr_vg[1][1],
+                ycbcr_vg_vert[1][6:],
+            ),
+            # c to chroma
+            Transform(
+                ycbcr_vg[2][0],
+                ycbcr_vg_vert[2][:6],
+            ),
+            # r to red
+            Transform(
+                ycbcr_vg[2][1],
+                ycbcr_vg_vert[2][6:],
+            ),
         )
         self.wait(2)
 
         # This color space aims to separate the luminance, or brightness
         # from the color components for a given value.
         self.play(Circumscribe(ycbcr_vg_vert[0], color=REDUCIBLE_VIOLET, run_time=2))
+
         self.wait(2)
+
         self.play(Circumscribe(ycbcr_vg_vert[1:], color=REDUCIBLE_VIOLET, run_time=2))
 
         self.play(*[FadeOut(mob) for mob in self.mobjects])

--- a/JPEGImageCompression/scenes.py
+++ b/JPEGImageCompression/scenes.py
@@ -3,6 +3,7 @@ File to define all the different scenes our video will be composed of.
 """
 
 from math import sqrt
+
 from manim import *
 import cv2
 from itertools import product
@@ -781,23 +782,21 @@ class ShowConfusingImage(Scene):
         """
 
 
-class MotivateAndExplainYCbCr(ThreeDScene):
-    def construct(self):
-        self.yuv_plane_animation()
-
-    def yuv_plane_animation(self):
-        color_plane = self.create_yuv_plane(y=127, color_res=128)
-
-        self.add(color_plane)
-
+class MotivateAndExplainRGB(ThreeDScene):
     def color_cube_animation(self):
         self.set_camera_orientation(phi=75 * DEGREES, theta=-45 * DEGREES)
         self.begin_ambient_camera_rotation(rate=1)
-        self.move_camera(zoom=0.8)
+        self.move_camera(zoom=0.5)
 
-        color_resolution = 4
+        # change this value to 8 or 16. 8 is pretty slow already, we may not need
+        # that much resolution for this small demo.
+        color_resolution = 3
+
         cubes_rgb = self.create_color_space_cube(
-            coords2rgbcolor, color_res=color_resolution, cube_side_length=1
+            coords2rgbcolor, color_res=color_resolution, cube_side_length=0.8
+        ).move_to(ORIGIN)
+        cubes_rgb_expanded = self.create_color_space_cube(
+            coords2rgbcolor, color_res=color_resolution, cube_side_length=0.8, buff=0.6
         ).move_to(ORIGIN)
 
         self.wait()
@@ -805,6 +804,8 @@ class MotivateAndExplainYCbCr(ThreeDScene):
         self.play(FadeIn(cubes_rgb))
 
         self.wait(6)
+
+        self.play(Transform(cubes_rgb, cubes_rgb_expanded))
 
         anim_group = []
         # this loop removes every cube that is not in the grayscale diagonal of the RGB colorspace.
@@ -824,7 +825,7 @@ class MotivateAndExplainYCbCr(ThreeDScene):
         color_space_func,
         color_res=8,
         cube_side_length=0.1,
-        buff=0.05,
+        buff=0,
     ):
         """
         Creates a YCbCr cube composed of many smaller cubes. The `color_res` argument defines
@@ -846,8 +847,7 @@ class MotivateAndExplainYCbCr(ThreeDScene):
         MAX_COLOR_RES = 256
         discrete_ratio = MAX_COLOR_RES // color_res
 
-        side_length = cube_side_length
-        offset = side_length + buff
+        offset = cube_side_length + buff
         cubes = []
 
         for i in range(color_res):
@@ -860,9 +860,9 @@ class MotivateAndExplainYCbCr(ThreeDScene):
 
                     color = color_space_func(i_discrete, j_discrete, k_discrete)
 
-                    curr_cube = Cube(fill_color=color, fill_opacity=1).shift(
-                        (LEFT * i + UP * j + OUT * k) * offset
-                    )
+                    curr_cube = Cube(
+                        fill_color=color, fill_opacity=1, side_length=cube_side_length
+                    ).shift((LEFT * i + UP * j + OUT * k) * offset)
 
                     cubes.append(curr_cube)
 
@@ -870,7 +870,172 @@ class MotivateAndExplainYCbCr(ThreeDScene):
 
         return cubes_rgb
 
-    def create_yuv_plane(self, y=127, color_res=64):
+
+class MotivateAndExplainYCbCr(Scene):
+    def construct(self):
+        self.ycbcr_explanation()
+        self.yuv_plane_animation()
+
+    def ycbcr_explanation(self):
+        y_t = Text("Y", font="CMU Serif", weight=BOLD).scale(1.5).set_color(GRAY_B)
+        u_t = (
+            Text("Cb", font="CMU Serif", weight=BOLD)
+            .scale(1.5)
+            .set_color_by_gradient("#FFFF00", "#0000FF")
+        )
+        v_t = (
+            Text("Cr", font="CMU Serif", weight=BOLD)
+            .scale(1.5)
+            .set_color_by_gradient("#00FF00", "#FF0000")
+        )
+
+        v_full_t = (
+            Text("Chroma red", font="CMU Serif", weight=BOLD)
+            .scale(1.5)
+            .set_color_by_gradient("#00FF00", "#FF0000")
+        )
+
+        u_full_t = (
+            Text("Chroma blue", font="CMU Serif", weight=BOLD)
+            .scale(1.5)
+            .set_color_by_gradient("#FFFF00", "#0000FF")
+        )
+
+        ycbcr_vg = VGroup(y_t, u_t, v_t).arrange(RIGHT, buff=1).scale(2)
+        ycbcr_vg_vert = (
+            VGroup(y_t.copy().scale(0.7), u_full_t, v_full_t)
+            .arrange(DOWN, buff=1)
+            .scale_to_fit_height(5)
+        )
+
+        # YCbCr stands for Y, Chroma Blue and Chroma Red.
+
+        self.play(LaggedStartMap(FadeIn, ycbcr_vg, lag_ratio=0.5))
+        self.wait()
+        self.play(
+            FadeTransformPieces(
+                ycbcr_vg,
+                ycbcr_vg_vert,
+                stretch=False,
+                # key_map={ycbcr_vg[-1][-2]: ycbcr_vg_vert[-1][6]},
+            )
+        )
+        self.wait(2)
+
+        # This color space aims to separate the luminance, or brightness
+        # from the color components for a given value.
+        self.play(Circumscribe(ycbcr_vg_vert[0], color=REDUCIBLE_VIOLET, run_time=2))
+        self.wait(2)
+        self.play(Circumscribe(ycbcr_vg_vert[1:], color=REDUCIBLE_VIOLET, run_time=2))
+
+        self.play(*[FadeOut(mob) for mob in self.mobjects])
+
+        self.wait()
+
+    def yuv_plane_animation(self):
+        yuv_title = (
+            Text("YCbCr color space", font="CMU Serif", weight=BOLD)
+            .scale(0.9)
+            .to_edge(UP, buff=0.6)
+        )
+
+        color_plane_0 = self.create_yuv_plane(y=0, color_res=32).move_to(DOWN * 0.5)
+        color_plane_127 = self.create_yuv_plane(y=127, color_res=32).move_to(DOWN * 0.5)
+        color_plane_255 = self.create_yuv_plane(y=255, color_res=32).move_to(DOWN * 0.5)
+        color_plane_0_loop = color_plane_0.copy()
+
+        color_planes = {}
+        for i in range(50, 256, 50):
+            color_planes.update(
+                {i: self.create_yuv_plane(i, color_res=32).move_to(color_plane_0)}
+            )
+
+        print(color_planes)
+
+        y = 0.00
+
+        y_number = (
+            RVariable(var=y, label="Y")
+            .scale(0.7)
+            .next_to(color_plane_0, DOWN, buff=0.5)
+        )
+
+        self.play(FadeIn(color_plane_0), FadeIn(yuv_title), FadeIn(y_number))
+
+        self.wait()
+
+        for y, plane in color_planes.items():
+            self.play(
+                Transform(color_plane_0, plane),
+                y_number.tracker.animate.set_value(y / 255),
+                run_time=2,
+            )
+            self.wait(2)
+
+        self.play(
+            Transform(color_plane_0, color_plane_0_loop),
+            y_number.tracker.animate.set_value(0.00001),
+        )
+        self.wait(2)
+        self.play(FadeOut(color_plane_0), FadeOut(y_number))
+        self.wait()
+
+        planes_diag = (
+            Group(color_plane_0, color_plane_127, color_plane_255)
+            .arrange(DOWN * 1.9 + RIGHT * 1.7, buff=-1.5)
+            .scale(0.7)
+            .move_to(DOWN * 0.5)
+        )
+
+        planes_from_side = (
+            planes_diag.copy()
+            .arrange(IN, buff=1)
+            .rotate(-90 * DEGREES, Y_AXIS)
+            .move_to(DOWN * 0.5)
+        )
+
+        self.play(FadeIn(planes_diag))
+        self.wait()
+        self.play(Transform(planes_diag, planes_from_side))
+        self.wait()
+
+        y_line = Line(
+            planes_from_side[0].get_center(), planes_from_side[-1].get_center()
+        ).set_stroke(GRAY)
+
+        y_0 = (
+            Text("0", font="SF Mono")
+            .scale(0.4)
+            .next_to(planes_from_side[0], UP, buff=0.3)
+        )
+        y_05 = (
+            Text("0.5", font="SF Mono")
+            .scale(0.4)
+            .next_to(planes_from_side[1], UP, buff=0.3)
+        )
+        y_1 = (
+            Text("1", font="SF Mono")
+            .scale(0.4)
+            .next_to(planes_from_side[2], UP, buff=0.3)
+        )
+
+        self.play(
+            Write(y_line),
+            LaggedStart(FadeIn(y_0), FadeIn(y_05), FadeIn(y_1), lag_ratio=0.1),
+            run_time=3,
+        )
+
+        self.play(*[FadeOut(mob) for mob in self.mobjects])
+
+    def create_yuv_plane(self, y=127, color_res=64, return_data=False):
+        """
+        Creates an array of data that corresponds to the U and V values mapped out
+        at a specific y setting. This can return the ndarray itself or an ImageMobject
+        ready to be used.
+
+        Color res at 32 using linear interpolation for the resampling can be quite
+        fast and efficient while still giving the illusion of a very smooth gradient.
+        """
         color_plane_data = [
             [y, u * (256 // color_res), v * (256 // color_res)]
             for u in range(color_res)
@@ -880,6 +1045,9 @@ class MotivateAndExplainYCbCr(ThreeDScene):
         rgb_conv = np.array(
             [ycbcr2rgb4map(c) for c in color_plane_data], dtype=np.uint8
         ).reshape((color_res, color_res, 3))
+
+        if return_data:
+            return rgb_conv
 
         mob = ImageMobject(rgb_conv)
         mob.set_resampling_algorithm(RESAMPLING_ALGORITHMS["linear"])


### PR DESCRIPTION
- minor changes
- created conversion functions to work withing mapping and list comprehension contexts
- created function to render the yuv plane at a specified y value
- override variable and decimal classes to have custom font
- separate rgb and yuv explanations and first draft at yuv explanation
- changed transformation for ycbcr text
- added title and fixed size of cubes for RGB representation
---

This PR adds the cube and RGB cubes animation and the YUV planes animation.

### `MotivateAndExplainRGB` 
A 3D scene with the cubes, ambient rotation and an animation to let the grayscale diagonal be shown.

### `MotivateAndExplainYCbCr`
- Normal scene with first an exposition of what the letters Y Cb and Cr mean. 
- Then we are presented with an animation of the YUV plane at Y=0 and we see how it progressively gets brighter as we increase the values of Y. 
- Then, the planes at y = 0, y = 0.5 and y = 1 are arranged and rotated 90 degrees to show how the line that goes through the center corresponds to the gray scale.

I separated these in two because one was 3D and the other one is not.

We are still missing the part of the CRT TVs, I'll search for some usable images to be added in FCP.