### PR TITLE
Extend functionality of `MarkovChainGraph` class 

### DIFF
--- a/PageRank/markov_chain.py
+++ b/PageRank/markov_chain.py
@@ -5,10 +5,13 @@ import sys
 sys.path.insert(1, "common/")
 
 from manim import *
-import networkx as nx
-import typing
+from manim.mobject.geometry.tips import ArrowTriangleFilledTip
 from reducible_colors import *
+
+from typing import Hashable
+
 import numpy as np
+import itertools as it
 
 np.random.seed(23)
 
@@ -81,6 +84,18 @@ class CustomLabel(Text):
         self.scale(scale)
 
 
+class CustomCurvedArrow(CurvedArrow):
+    def __init__(self, start, end, tip_length=0.15, **kwargs):
+        super().__init__(start, end, **kwargs)
+        self.pop_tips()
+        self.add_tip(
+            tip_shape=ArrowTriangleFilledTip,
+            tip_length=tip_length,
+            at_start=False,
+        )
+        self.tip.z_index = -100
+
+
 class MarkovChainGraph(Graph):
     def __init__(
         self,
@@ -91,38 +106,150 @@ class MarkovChainGraph(Graph):
             "fill_color": REDUCIBLE_PURPLE,
             "fill_opacity": 0.5,
         },
-        edge_config={
-            "color": REDUCIBLE_VIOLET,
-            "max_tip_length_to_length_ratio": 0.06,
-            "stroke_width": 3,
-        },
-        **kwargs
+        **kwargs,
     ):
         self.markov_chain = markov_chain
         super().__init__(
             markov_chain.get_states(),
             markov_chain.get_edges(),
             vertex_config=vertex_config,
-            edge_config=edge_config,
-            edge_type=Arrow,
             labels={
                 k: CustomLabel(str(k), scale=0.6) for k in markov_chain.get_states()
             },
-            **kwargs
+            **kwargs,
         )
-        for edge in self.edges:
-            self.scale_edge_arrow(edge)
 
-    def scale_edge_arrow(self, edge: tuple[int, int]):
+        self._graph = self._graph.to_directed()
+        self.remove_edges(*self.edges)
+
+        self.add_markov_chain_edges(*markov_chain.get_edges())
+
+        self.clear_updaters()
+
+        def update_edges(graph):
+            for (u, v), edge in graph.edges.items():
+                v_c = self.vertices[v].get_center()
+                u_c = self.vertices[u].get_center()
+                vec = v_c - u_c
+                unit_vec = vec / np.linalg.norm(vec)
+
+                arrow_start = u_c + unit_vec * self.vertices[u].radius
+                arrow_end = v_c - unit_vec * self.vertices[v].radius
+                edge.put_start_and_end_on(arrow_start, arrow_end)
+
+        self.add_updater(update_edges)
+
+    def add_edge_buff(
+        self,
+        edge: tuple[Hashable, Hashable],
+        edge_type: type[Mobject] = None,
+        edge_config: dict = None,
+    ):
+        """
+        Custom function to add edges to our Markov Chain
+        """
+        if edge_config is None:
+            edge_config = self.default_edge_config.copy()
+        added_mobjects = []
+        for v in edge:
+            if v not in self.vertices:
+                added_mobjects.append(self._add_vertex(v))
         u, v = edge
-        arrow = self.edges[edge]
+
+        self._graph.add_edge(u, v)
+
+        base_edge_config = self.default_edge_config.copy()
+        base_edge_config.update(edge_config)
+        edge_config = base_edge_config
+        self._edge_config[(u, v)] = edge_config
+
         v_c = self.vertices[v].get_center()
         u_c = self.vertices[u].get_center()
         vec = v_c - u_c
         unit_vec = vec / np.linalg.norm(vec)
+
         arrow_start = u_c + unit_vec * self.vertices[u].radius
         arrow_end = v_c - unit_vec * self.vertices[v].radius
-        self.edges[edge] = Arrow(arrow_start, arrow_end)
+
+        edge_mobject = edge_type(
+            start=arrow_start, end=arrow_end, z_index=-100, **edge_config
+        )
+        self.edges[(u, v)] = edge_mobject
+
+        self.add(edge_mobject)
+        added_mobjects.append(edge_mobject)
+        return self.get_group_class()(*added_mobjects)
+
+    def add_markov_chain_edges(
+        self,
+        *edges: tuple[Hashable, Hashable],
+        edge_config: dict = None,
+        **kwargs,
+    ):
+        """
+        Custom function for our specific case of Markov Chains.
+        This function aims to make double arrows curved when two nodes
+        point to each other, leaving the other ones straight.
+
+        """
+
+        if edge_config is None:
+            edge_config = {}
+        non_edge_settings = {k: v for (k, v) in edge_config.items() if k not in edges}
+        base_edge_config = self.default_edge_config.copy()
+        base_edge_config.update(non_edge_settings)
+
+        base_edge_config = {e: base_edge_config.copy() for e in edges}
+        for e in edges:
+            base_edge_config[e].update(edge_config.get(e, {}))
+        edge_config = base_edge_config
+
+        edge_vertices = set(it.chain(*edges))
+        new_vertices = [v for v in edge_vertices if v not in self.vertices]
+        added_vertices = self.add_vertices(*new_vertices, **kwargs)
+
+        edge_types_dict = {}
+        for e in edges:
+            if (e[1], e[0]) in edges:
+                edge_types_dict.update(
+                    {
+                        e: (
+                            CustomCurvedArrow,
+                            {
+                                "color": REDUCIBLE_VIOLET,
+                                "stroke_width": 3,
+                                "radius": 4,
+                            },
+                        )
+                    }
+                )
+            else:
+                edge_types_dict.update(
+                    {
+                        e: (
+                            Arrow,
+                            {
+                                "color": REDUCIBLE_VIOLET,
+                                "max_tip_length_to_length_ratio": 0.06,
+                                "stroke_width": 3,
+                            },
+                        )
+                    }
+                )
+
+        added_mobjects = sum(
+            (
+                self.add_edge_buff(
+                    edge,
+                    edge_type=e_type_and_config[0],
+                    edge_config=e_type_and_config[1],
+                ).submobjects
+                for edge, e_type_and_config in edge_types_dict.items()
+            ),
+            added_vertices,
+        )
+
+        return self.get_group_class()(*added_mobjects)
 
     def get_transition_labels(self):
         """
@@ -137,13 +264,14 @@ class MarkovChainGraph(Graph):
         be created.
         """
         tm = self.markov_chain.get_transition_matrix()
+
         labels = VGroup()
         for s in range(len(tm)):
             for e in range(len(tm[0])):
                 if s != e and tm[s, e] != 0:
+
                     edge_tuple = (s, e)
                     matrix_prob = tm[s, e]
-                    print(edge_tuple, matrix_prob)
 
                     labels.add(
                         Text(str(matrix_prob), font=REDUCIBLE_MONO)
@@ -176,7 +304,7 @@ class MarkovChainSimulator:
             for i in range(self.num_users)
         }
         self.users = [
-            Dot(radius=0.05)
+            Dot(radius=0.035)
             .set_color(REDUCIBLE_YELLOW)
             .set_opacity(0.6)
             .set_stroke(REDUCIBLE_YELLOW, width=2, opacity=0.8)
@@ -300,14 +428,17 @@ class MarkovChainTester(Scene):
                 *[LaggedStart(*transition_map[i]) for i in markov_chain.get_states()]
             )
             self.wait()
-            
+
+
 class MarkovChainIntro(Scene):
     def construct(self):
         pass
 
+
 class IntroImportanceProblem(Scene):
     def construct(self):
         pass
+
 
 class IntroStationaryDistribution(Scene):
     def construct(self):

--- a/PageRank/markov_chain.py
+++ b/PageRank/markov_chain.py
@@ -1,4 +1,3 @@
-from logging import Filterer
 import sys
 
 ### THIS IS A WORKAROUND FOR NOW


### PR DESCRIPTION
This PR solves the (extremely unnecessarily difficult) problem of displaying double arrows as curved — that is, when two nodes point at each other, so the arrows don't overlap.

The process involved rewriting and customizing big part of the `MarkovChainGraph` class, but hopefully these modifications aimed at making the overall class more robust and stable to changes and animations.

The functionality remains the exact same, though customizability might have been just a tad affected. Nothing that cannot be easily fixed, though. We'll see.

This is an example of how the default use of the class looks like as per these commits:

```python
small_mc = MarkovChain(3, edges=[(0, 1), (0, 2), (1, 2), (2, 1), (1, 0)])
small_mc_mob = MarkovChainGraph(small_mc)
self.play(Write(small_mc_mob))

markov_chain_sim = MarkovChainSimulator(small_mc, small_mc_mob, num_users=50)
users = markov_chain_sim.get_users()
self.play(*[FadeIn(user) for user in users])

```
![aaaaa](https://user-images.githubusercontent.com/50735312/165347464-cf21cf1b-f533-4ac8-b329-b98f33212714.png)
