### PR TITLE
RED-44: MarkovSim breaks when a node is a sink

### DIFF
--- a/PageRank/markov_chain.py
+++ b/PageRank/markov_chain.py
@@ -51,6 +51,11 @@ class MarkovChain:
                 for neighbor in neighbors:
                     self.transition_matrix[state][neighbor] = 1 / len(neighbors)
 
+        # handle sink nodes to point to itself
+        for i, row in enumerate(self.transition_matrix):
+            if np.sum(row) == 0:
+                self.transition_matrix[i][i] = 1
+
         if dist is not None:
             self.dist = dist
         else:
@@ -487,7 +492,6 @@ class MarkovChainSimulator:
 
 class MarkovChainTester(Scene):
     def construct(self):
-
         markov_chain = MarkovChain(
             4,
             [(0, 1), (1, 0), (0, 2), (1, 2), (1, 3), (2, 3), (3, 1)],


### PR DESCRIPTION
[Problem]
When a node is a sink, the row of the transition matrix of that node sums to 0, which is an invalid probability distribution, which crashes the sim with a ValueError

[Solution]
In initialization of a Markov Chain object, iterate through rows of transition matrix and if the row sums to 0, create a transition of probability 1 to the node itself, which makes the distribution valid

[Test]
Tested on MarkovChainTester Scene with (3, 1) edge removed. Simulation no longer breaks. 
Tested all other scenes for regressions and no regressions found. 