### PR TITLE
RED-103: Fix bug with overlapping edges

### DIFF
--- a/TSPProblem/solving_tsp.py
+++ b/TSPProblem/solving_tsp.py
@@ -49,6 +49,10 @@ class TSPGraph(Graph):
             labels=labels,
             **kwargs,
         )
+        ### RED-103: Vertices should be the same size (even for larger labels)
+        for v in self.vertices:
+            if v >= 10:
+                self.vertices[v].scale_to_fit_height(self.vertices[0].height)
         self.edge_config = edge_config
         if dist_matrix is None:
             self.dist_matrix = np.zeros((len(vertices), len(vertices)))
@@ -115,22 +119,18 @@ class TSPGraph(Graph):
 
 class TSPTester(Scene):
     def construct(self):
-        graph = TSPGraph([0, 1, 2, 3, 4, 5])
-        self.play(FadeIn(graph))
+        big_graph = TSPGraph(range(12), layout_scale=2.4, layout="circular")
+        all_edges_bg = big_graph.get_all_edges()
+        self.play(
+            FadeIn(big_graph)
+        )
         self.wait()
-        print(graph.dist_matrix)
 
-        # all_edges = graph.get_all_edges()
+        self.play(
+            *[FadeIn(edge) for edge in all_edges_bg.values()]
+        )
+        self.wait()
 
-        all_tour_permutations = get_all_tour_permutations(len(graph.vertices), 0)
-        for tour in all_tour_permutations:
-            tour_edges = graph.get_tour_edges(tour)
-            tour_dist_labels = graph.get_tour_dist_labels(tour_edges)
-            self.add(*tour_edges.values())
-            self.add(*tour_dist_labels.values())
-            self.wait()
-            self.remove(*tour_edges.values())
-            self.remove(*tour_dist_labels.values())
 
 class NearestNeighbor(Scene):
     def construct(self):


### PR DESCRIPTION
[Problem]
When more than 10 vertices exist in the graph, since labels of 10 or more need more space, default behavior is vertices are bigger. This causes the constant edge buff invariant to break, causing overlapping edge.

[Solution]
On initialization of TSP graph, scale all vertices to the height of the smallest vertices (all one digit labeled vertices).

[Test]
Bug is fixed on test scene. All existing scenes work -- no regressions found.

https://user-images.githubusercontent.com/14256908/173514328-2c0409d7-3fff-4da9-85bd-e84606332245.mp4

 