### PR TITLE
RED-137: IntroducePhaseProblem

### DIFF
--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -334,7 +334,7 @@ def get_rectangles_for_matrix_transform(
                     Text(str(i), font=REDUCIBLE_MONO).scale(0.4),
                 ).arrange(DOWN)
                 for i, f in enumerate(
-                    matrix_transform.flatten()[: matrix_transform.shape[0] // 2]
+                    matrix_transform.flatten()[: matrix_transform.shape[0]]
                 )
             ]
         )

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -109,6 +109,10 @@ def get_sum_functions(*time_functions):
     return lambda x: sum([f(x) for f in time_functions])
 
 
+def get_prod_functions(*time_functions):
+    return lambda x: np.prod([f(x) for f in time_functions])
+
+
 def get_cosine_func(amplitude=1, freq=1, phase=0, b=0):
     return lambda x: amplitude * np.cos(freq * x + phase) + b
 

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -458,39 +458,6 @@ def get_fourier_with_sample_points_and_vert_lines(
     return VGroup(graph, axes, sampled_points, vertical_lines)
 
 
-def get_fourier_bar_chart(
-    time_func,
-    t_min=0,
-    t_max=10,
-    f_min=0,
-    f_max=10,
-    n_samples=NUM_SAMPLES_FOR_FFT,
-    bar_width=0.2,
-    height_scale=1,
-    color=FREQ_DOMAIN_COLOR,
-):
-
-    time_range = float(t_max - t_min)
-    time_samples = np.vectorize(time_func)(np.linspace(t_min, t_max, n_samples))
-    fft_output = np.fft.fft(time_samples)
-    frequencies = np.linspace(0.0, n_samples / (2.0 * time_range), n_samples // 2)
-
-    graph = VGroup()
-
-    for x, y in zip(frequencies, fft_output[: n_samples // 2]):
-        if x <= f_max + 0.1:
-            rect = (
-                Rectangle(height=height_scale * np.abs(y) / n_samples, width=bar_width)
-                .set_color(color)
-                .set_fill(color, opacity=1)
-                .set_stroke(width=1)
-            )
-            graph.add(rect)
-
-    graph.arrange(RIGHT, buff=0.1, aligned_edge=DOWN)
-    return graph
-
-
 def get_fourier_rects(
     signal_func,
     n_samples=32,

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -135,12 +135,14 @@ def inner_prod(time_domain_func, freq_func, x_min=0, x_max=2 * PI, num_points=8)
     return np.dot(y_coords_time, y_coords_freq)
 
 
-def get_sampled_dots(graph, axes, x_min=0, x_max=2 * PI, num_points=8):
+def get_sampled_dots(
+    graph, axes, x_min=0, x_max=2 * PI, num_points=8, radius=DEFAULT_DOT_RADIUS
+):
     x_coords, y_coords = get_sampled_coords(
         graph, x_min=x_min, x_max=x_max, num_points=num_points
     )
     coord_dots = [
-        Dot().move_to(axes.coords_to_point(x_coord, y_coord))
+        Dot(radius=radius).move_to(axes.coords_to_point(x_coord, y_coord))
         for x_coord, y_coord in zip(x_coords, y_coords)
     ]
     return VGroup(*coord_dots)

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -299,3 +299,47 @@ def get_analysis_frequency_matrix(N, sample_rate, t_min=0, t_max=2 * PI):
     return np.array(
         [[f(s) for s in np.linspace(t_min, t_max, num=N, endpoint=False)] for f in af]
     )
+
+
+def get_rectangles_for_matrix_transform(
+    sampled_signal, analysis_frequency_matrix, rect_scale=0.1
+):
+    """
+    Create an array of rectangles with annotations to represent the matrix transform input.
+
+    INPUTS
+    ------
+    This function accepts a sampled signal and an analysis frequency matrix to transform the signal.
+    The sampled signal is an array of values and the analysis frequency matrix is a 2D square array of
+    N analysis frequencies sampled at N points.
+
+    The rectangle scaling argument is there to control the height of the rectangles, since
+    the values can get pretty wild if not controlled properly.
+
+    RETURN
+    ------
+    The function returns a VGroup of rectangles and text, and this VGroup is already aligned down,
+    in order for it to work properly with redrawing animations.
+    """
+
+    matrix_transform = apply_matrix_transform(sampled_signal, analysis_frequency_matrix)
+
+    rects = (
+        VGroup(
+            *[
+                VGroup(
+                    Rectangle(
+                        color=REDUCIBLE_VIOLET, width=0.3, height=f * rect_scale
+                    ).set_fill(REDUCIBLE_VIOLET, opacity=1),
+                    Text(str(i), font=REDUCIBLE_MONO).scale(0.4),
+                ).arrange(DOWN)
+                for i, f in enumerate(
+                    matrix_transform.flatten()[: matrix_transform.shape[0] // 2]
+                )
+            ]
+        )
+        .arrange(RIGHT, aligned_edge=DOWN)
+        .scale(0.6)
+        .move_to(DOWN * 3.4, aligned_edge=DOWN)
+    )
+    return rects

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -280,7 +280,7 @@ def make_row_vector(values, h_buff=0.6, scale=0.6):
     return vector.scale(scale)
 
 
-def get_analysis_frequency_matrix(N, sample_rate, t_min=0, t_max=2 * PI):
+def get_analysis_frequency_matrix(N, sample_rate, func="cos", t_min=0, t_max=2 * PI):
     """
     Constructs a N x N matrix of N analysis frequencies
     sampled at N points.
@@ -288,10 +288,23 @@ def get_analysis_frequency_matrix(N, sample_rate, t_min=0, t_max=2 * PI):
     The matrix holds the values in columns,
     as in the N values of the Nth analysis frequency are stored in
     column number N.
+
+    We can choose how the transform is calculated, if using sine or cosine
+    functions. Just pass 'sin' to the "func" argument. By default, this value
+    is set to 'cos'.
     """
 
+    print(func)
+    if func != "cos" and func != "sin":
+        raise ValueError('func can either be "cos" or "sin"')
+
+    if func == "cos":
+        signal_func = get_cosine_func
+    else:
+        signal_func = get_sine_func
+
     # analysis frequencies
-    af = [get_cosine_func(freq=sample_rate * m / N) for m in range(N // 2)]
+    af = [signal_func(freq=sample_rate * m / N) for m in range(N // 2)]
 
     # for each analysis frequency, sample that function along N points
     # this returns the frequencies per rows, so .T transposes and

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -93,7 +93,8 @@ def plot_time_domain(
     color=TIME_DOMAIN_COLOR,
 ):
     time_axis = get_time_axis(
-        x_range=[t_min, t_max, t_step], y_range=[y_min, y_max, y_step]
+        x_range=[t_min, t_max, t_step],
+        y_range=[y_min, y_max, y_step],
     )
     graph = time_axis.plot(time_func).set_color(color)
 

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -316,7 +316,7 @@ def get_analysis_frequency_matrix(
     selected_spectrum = N if full_spectrum else N // 2
 
     # analysis frequencies
-    af = [signal_func(freq=sample_rate * m / N) for m in range(N)]
+    af = [signal_func(freq=sample_rate * m / N) for m in range(N // 2)]
 
     # for each analysis frequency, sample that function along N points
     # this returns the frequencies per rows, so .T transposes and
@@ -354,7 +354,9 @@ def get_rectangles_for_matrix_transform(
             *[
                 VGroup(
                     Rectangle(
-                        color=REDUCIBLE_VIOLET, width=0.3, height=f * rect_scale
+                        color=REDUCIBLE_VIOLET,
+                        width=0.3,
+                        height=f * rect_scale if f * rect_scale > 0.01 else 0.01,
                     ).set_fill(REDUCIBLE_VIOLET, opacity=1),
                     Text(str(i), font=REDUCIBLE_MONO).scale(0.4),
                 ).arrange(DOWN)

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -316,16 +316,13 @@ def get_analysis_frequency_matrix(
     selected_spectrum = N if full_spectrum else N // 2
 
     # analysis frequencies
-    af = [signal_func(freq=sample_rate * m / N) for m in range(N)]
+    af = [signal_func(freq=sample_rate * m / N) for m in range(selected_spectrum)]
 
     # for each analysis frequency, sample that function along N points
     # this returns the frequencies per rows, so .T transposes and
     # have the signal values in cols
     return np.array(
-        [
-            [f(s) for s in np.linspace(t_min, t_max, num=N, endpoint=False)]
-            for f in af[:selected_spectrum]
-        ]
+        [[f(s) for s in np.linspace(t_min, t_max, num=N, endpoint=False)] for f in af]
     )
 
 
@@ -478,7 +475,7 @@ def get_fourier_rects(
     # idea: sample points from get_fourier_line_chart
     # and create num_bars dynamically to scale with the axes size
     af_matrix = get_analysis_frequency_matrix(
-        N=n_samples, sample_rate=sample_rate, t_max=t_max
+        N=n_samples, sample_rate=sample_rate, t_max=t_max, full_spectrum=False
     )
     sampled_signal = np.array(
         [

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -277,3 +277,22 @@ def make_row_vector(values, h_buff=0.6, scale=0.6):
             integer_values.append(int(value))
     vector = Matrix([[value for value in integer_values]], h_buff=h_buff)
     return vector.scale(scale)
+
+
+def get_analysis_frequency_matrix(N):
+    """
+    Constructs a N x N matrix of N analysis frequencies
+    sampled at N points.
+
+    The matrix holds the values in columns,
+    as in the N values of the Nth analysis frequency are stored in
+    column number N.
+    """
+
+    # analysis frequencies
+    af = [get_cosine_func(freq=n) for n in range(N)]
+
+    # for each analysis frequency, sample that function along N points
+    # this returns the frequencies per rows, so .T transposes and
+    # have the signal values in cols
+    return np.array([[f(s) for s in range(N)] for f in af]).T

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -279,7 +279,7 @@ def make_row_vector(values, h_buff=0.6, scale=0.6):
     return vector.scale(scale)
 
 
-def get_analysis_frequency_matrix(N, t_min=0, t_max=2 * PI):
+def get_analysis_frequency_matrix(N, duration, t_min=0, t_max=2 * PI):
     """
     Constructs a N x N matrix of N analysis frequencies
     sampled at N points.
@@ -290,7 +290,7 @@ def get_analysis_frequency_matrix(N, t_min=0, t_max=2 * PI):
     """
 
     # analysis frequencies
-    af = [get_cosine_func(freq=n) for n in range(N)]
+    af = [get_cosine_func(freq=n / duration) for n in range(N)]
 
     # for each analysis frequency, sample that function along N points
     # this returns the frequencies per rows, so .T transposes and

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -279,7 +279,7 @@ def make_row_vector(values, h_buff=0.6, scale=0.6):
     return vector.scale(scale)
 
 
-def get_analysis_frequency_matrix(N):
+def get_analysis_frequency_matrix(N, t_min=0, t_max=2 * PI):
     """
     Constructs a N x N matrix of N analysis frequencies
     sampled at N points.
@@ -295,4 +295,6 @@ def get_analysis_frequency_matrix(N):
     # for each analysis frequency, sample that function along N points
     # this returns the frequencies per rows, so .T transposes and
     # have the signal values in cols
-    return np.array([[f(s) for s in range(N)] for f in af]).T
+    return np.array(
+        [[f(s) for s in np.linspace(t_min, t_max, num=N, endpoint=False)] for f in af]
+    ).T

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -279,7 +279,7 @@ def make_row_vector(values, h_buff=0.6, scale=0.6):
     return vector.scale(scale)
 
 
-def get_analysis_frequency_matrix(N, duration, t_min=0, t_max=2 * PI):
+def get_analysis_frequency_matrix(N, sample_rate, t_min=0, t_max=2 * PI):
     """
     Constructs a N x N matrix of N analysis frequencies
     sampled at N points.
@@ -290,11 +290,11 @@ def get_analysis_frequency_matrix(N, duration, t_min=0, t_max=2 * PI):
     """
 
     # analysis frequencies
-    af = [get_cosine_func(freq=n / duration) for n in range(N)]
+    af = [get_cosine_func(freq=sample_rate * m / N) for m in range(N // 2)]
 
     # for each analysis frequency, sample that function along N points
     # this returns the frequencies per rows, so .T transposes and
     # have the signal values in cols
     return np.array(
         [[f(s) for s in np.linspace(t_min, t_max, num=N, endpoint=False)] for f in af]
-    ).T
+    )

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -501,7 +501,9 @@ def get_fourier_rects_from_custom_matrix(
         ]
     ).arrange(RIGHT, aligned_edge=DOWN)
 
-    frequency_label = Text("Frequency", font=REDUCIBLE_MONO).scale(font_scale / 1.2)
+    frequency_label = Text("Frequency", font=REDUCIBLE_FONT, weight=BOLD).scale(
+        font_scale / 1.2
+    )
     frequency_label.next_to(rects, DOWN)
 
     return VGroup(rects, frequency_label)

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -316,7 +316,7 @@ def get_analysis_frequency_matrix(
     selected_spectrum = N if full_spectrum else N // 2
 
     # analysis frequencies
-    af = [signal_func(freq=sample_rate * m / N) for m in range(selected_spectrum)]
+    af = [signal_func(freq=sample_rate * m / N) for m in range(N)]
 
     # for each analysis frequency, sample that function along N points
     # this returns the frequencies per rows, so .T transposes and
@@ -471,11 +471,12 @@ def get_fourier_rects(
     rect_scale=0.1,
     rect_width=0.3,
     font_scale=0.4,
+    full_spectrum=False,
 ):
     # idea: sample points from get_fourier_line_chart
     # and create num_bars dynamically to scale with the axes size
     af_matrix = get_analysis_frequency_matrix(
-        N=n_samples, sample_rate=sample_rate, t_max=t_max, full_spectrum=False
+        N=n_samples, sample_rate=sample_rate, t_max=t_max, full_spectrum=full_spectrum
     )
     sampled_signal = np.array(
         [

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -289,7 +289,9 @@ def make_row_vector(values, h_buff=0.6, scale=0.6):
     return vector.scale(scale)
 
 
-def get_analysis_frequency_matrix(N, sample_rate, func="cos", t_min=0, t_max=2 * PI):
+def get_analysis_frequency_matrix(
+    N, sample_rate, func="cos", t_min=0, t_max=2 * PI, full_spectrum=False
+):
     """
     Constructs a N x N matrix of N analysis frequencies
     sampled at N points.
@@ -311,6 +313,8 @@ def get_analysis_frequency_matrix(N, sample_rate, func="cos", t_min=0, t_max=2 *
     else:
         signal_func = get_sine_func
 
+    selected_spectrum = N if full_spectrum else N // 2
+
     # analysis frequencies
     af = [signal_func(freq=sample_rate * m / N) for m in range(N)]
 
@@ -318,7 +322,10 @@ def get_analysis_frequency_matrix(N, sample_rate, func="cos", t_min=0, t_max=2 *
     # this returns the frequencies per rows, so .T transposes and
     # have the signal values in cols
     return np.array(
-        [[f(s) for s in np.linspace(t_min, t_max, num=N, endpoint=False)] for f in af]
+        [
+            [f(s) for s in np.linspace(t_min, t_max, num=N, endpoint=False)]
+            for f in af[:selected_spectrum]
+        ]
     )
 
 

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -218,16 +218,19 @@ def get_fourier_bar_chart(
     bar_width=0.2,
     height_scale=1,
     color=FREQ_DOMAIN_COLOR,
+    full_spectrum=False,
 ):
+
+    spectrum_selection = n_samples if full_spectrum else n_samples // 2
 
     time_range = float(t_max - t_min)
     time_samples = np.vectorize(time_func)(np.linspace(t_min, t_max, n_samples))
     fft_output = np.fft.fft(time_samples)
-    frequencies = np.linspace(0.0, n_samples / (2.0 * time_range), n_samples // 2)
+    frequencies = np.linspace(0.0, n_samples / (2.0 * time_range), spectrum_selection)
 
     graph = VGroup()
 
-    for x, y in zip(frequencies, fft_output[: n_samples // 2]):
+    for x, y in zip(frequencies, fft_output[:spectrum_selection]):
         if x <= f_max + 0.1:
             rect = (
                 Rectangle(height=height_scale * np.abs(y) / n_samples, width=bar_width)

--- a/DFT/dft_utils.py
+++ b/DFT/dft_utils.py
@@ -298,7 +298,6 @@ def get_analysis_frequency_matrix(N, sample_rate, func="cos", t_min=0, t_max=2 *
     is set to 'cos'.
     """
 
-    print(func)
     if func != "cos" and func != "sin":
         raise ValueError('func can either be "cos" or "sin"')
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -596,7 +596,7 @@ class IntroducePhaseProblem(MovingCameraScene):
         original_freq = 2
 
         # samples per second
-        sample_frequency = 40
+        sample_frequency = 10
 
         n_samples = sample_frequency
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1941,7 +1941,7 @@ class InterpretDFT(MovingCameraScene):
                 t_max=t_max,
                 n_samples=n_samples,
                 full_spectrum=True,
-                height_scale=2,
+                height_scale=4,
             )
 
             return (
@@ -1957,6 +1957,31 @@ class InterpretDFT(MovingCameraScene):
             FadeOut(main_signal_mob),
             FadeIn(main_signal_mob_changing),
             FadeIn(dft_barchart_changing),
+            *[indices[idx].animate.set_opacity(1) for idx in range(n_samples)],
+            *[
+                sin_af_matrix[idx][1].animate.set_stroke(opacity=1)
+                for idx in range(n_samples)
+            ],
+            *[
+                cos_af_matrix[idx][1].animate.set_stroke(opacity=1)
+                for idx in range(n_samples)
+            ],
+            *[
+                sampled_points_cos_af[idx].animate.set_opacity(1)
+                for idx in range(n_samples)
+            ],
+            *[
+                sampled_points_sin_af[idx].animate.set_opacity(1)
+                for idx in range(n_samples)
+            ],
         )
         self.wait()
         self.play(vt_phase.animate.set_value(PI / 2))
+        self.wait()
+        self.play(vt_frequency.animate.set_value(analysis_frequencies[0]))
+        self.wait()
+        self.play(vt_frequency.animate.set_value(analysis_frequencies[1]))
+        self.wait()
+        self.play(vt_frequency.animate.set_value(analysis_frequencies[2]))
+        self.wait()
+        self.play(vt_frequency.animate.set_value(analysis_frequencies[3]))

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1261,15 +1261,14 @@ class SolvingPhaseProblem(MovingCameraScene):
 
         def redraw_arc():
             radius = Line(number_plane.c2p(0, 0), number_plane.c2p(1, 0)).width
-            np_center = number_plane.c2p(0, 0)
-            arc_center = (np_center[0], np_center[1], 0)
             return (
                 Arc(radius, angle=vt_phase.get_value())
-                .move_arc_center_to(arc_center)
+                .move_arc_center_to(number_plane.c2p(0, 0))
                 .set_color(REDUCIBLE_YELLOW)
             )
 
         arc = always_redraw(redraw_arc)
+        arc.move_arc_center_to(number_plane.c2p(0, 0))
 
         self.play(Write(number_plane), vt_phase.animate.set_value(0))
         self.play(FadeIn(arc))

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -874,9 +874,13 @@ class IntroducePhaseProblem(MovingCameraScene):
 
 class SolvingPhaseProblem(MovingCameraScene):
     def construct(self):
-        frame = self.camera.frame
+        frame = self.camera.frame.save_state()
 
-        # self.hacky_sine_waves()
+        self.hacky_sine_waves()
+
+        self.play(*[FadeOut(mob) for mob in self.mobjects])
+        self.play(Restore(frame))
+
         self.capture_sine_and_cosine_transforms()
 
     def hacky_sine_waves(self):
@@ -884,7 +888,7 @@ class SolvingPhaseProblem(MovingCameraScene):
         t_max = PI
 
         # samples per second
-        sample_frequency = 80
+        sample_frequency = 40
 
         # total number of samples
         n_samples = sample_frequency
@@ -933,26 +937,7 @@ class SolvingPhaseProblem(MovingCameraScene):
                 ]
             ).reshape(-1, 1)
 
-            # matrix transform
-            mt = apply_matrix_transform(sampled_signal, af_matrix)
-
-            rect_scale = 0.1
-            rects = (
-                VGroup(
-                    *[
-                        VGroup(
-                            Rectangle(
-                                color=REDUCIBLE_VIOLET, width=0.3, height=f * rect_scale
-                            ).set_fill(REDUCIBLE_VIOLET, opacity=1),
-                            Text(str(i), font=REDUCIBLE_MONO).scale(0.4),
-                        ).arrange(DOWN)
-                        for i, f in enumerate(mt.flatten()[: mt.shape[0] // 2])
-                    ]
-                )
-                .arrange(RIGHT, aligned_edge=DOWN)
-                .scale(0.6)
-                .move_to(DOWN * 3.4, aligned_edge=DOWN)
-            )
+            rects = get_rectangles_for_matrix_transform(sampled_signal, af_matrix)
             return rects
 
         af_mob = always_redraw(change_af_cos_sin)
@@ -999,7 +984,7 @@ class SolvingPhaseProblem(MovingCameraScene):
         t_max = PI
 
         # samples per second
-        sample_frequency = 80
+        sample_frequency = 40
 
         # total number of samples
         n_samples = sample_frequency

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -596,7 +596,7 @@ class IntroducePhaseProblem(MovingCameraScene):
         original_freq = 2
 
         # samples per second
-        sample_frequency = 80
+        sample_frequency = 40
 
         n_samples = sample_frequency
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -812,6 +812,20 @@ class IntroducePhaseProblem(MovingCameraScene):
             )
             return text_group
 
+        display_axes_lines = (
+            display_signal(
+                get_cosine_func(
+                    amplitude=vt_amplitude.get_value(),
+                    freq=vt_frequency.get_value(),
+                    phase=vt_phase.get_value(),
+                    b=vt_b.get_value(),
+                )
+            )
+            .scale(0.6)
+            .shift(UP)
+        )
+        axes_and_lines = VGroup(display_axes_lines[0], display_axes_lines[1])
+
         def change_phase_redraw():
             phase_ch_cos = get_cosine_func(
                 amplitude=vt_amplitude.get_value(),
@@ -820,7 +834,10 @@ class IntroducePhaseProblem(MovingCameraScene):
                 b=vt_b.get_value(),
             )
             changing_signal = display_signal(phase_ch_cos)
-            return changing_signal.scale(0.6).shift(UP)
+
+            # we only return the displayed signal
+            changing_signal_and_points = VGroup(changing_signal[2], changing_signal[3])
+            return changing_signal_and_points.scale(0.6).shift(UP)
 
         af_matrix = get_analysis_frequency_matrix(
             N=n_samples, sample_rate=sample_frequency, t_max=t_max
@@ -844,7 +861,7 @@ class IntroducePhaseProblem(MovingCameraScene):
         freq_analysis = always_redraw(updating_transform_redraw)
         changing_tex_group = always_redraw(change_text_redraw)
 
-        self.play(Write(changing_signal_mob), FadeIn(freq_analysis))
+        self.play(Write(changing_signal_mob), FadeIn(freq_analysis, axes_and_lines))
         self.play(FadeIn(changing_tex_group))
 
         self.play(

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -8,7 +8,8 @@ from manim import *
 
 from dft_utils import *
 from reducible_colors import *
-from math import degrees, radians
+from math import degrees
+from classes import CustomLabel
 
 
 class IntroSampling_002(MovingCameraScene):
@@ -874,12 +875,12 @@ class IntroducePhaseProblem(MovingCameraScene):
 
 class SolvingPhaseProblem(MovingCameraScene):
     def construct(self):
-        frame = self.camera.frame.save_state()
+        # frame = self.camera.frame.save_state()
 
-        self.hacky_sine_waves()
+        # self.hacky_sine_waves()
 
-        self.play(*[FadeOut(mob) for mob in self.mobjects])
-        self.play(Restore(frame))
+        # self.play(*[FadeOut(mob) for mob in self.mobjects])
+        # self.play(Restore(frame))
 
         self.capture_sine_and_cosine_transforms()
 
@@ -1005,6 +1006,51 @@ class SolvingPhaseProblem(MovingCameraScene):
         vt_phase = ValueTracker(0)
 
         scale = 0.4
+        dot_prod_scale = 1
+
+        def get_dot_prod_cos_bar():
+            cos_analysis_freq = get_cosine_func(freq=original_frequency)
+            sin_analysis_freq = get_sine_func(freq=original_frequency)
+
+            og_signal = get_cosine_func(
+                freq=original_frequency, phase=vt_phase.get_value()
+            )
+
+            cos_dot_prod = (
+                inner_prod(
+                    og_signal,
+                    cos_analysis_freq,
+                    x_max=t_max,
+                    num_points=sample_frequency,
+                )
+                * dot_prod_scale
+            )
+            sin_dot_prod = (
+                inner_prod(
+                    og_signal,
+                    sin_analysis_freq,
+                    x_max=t_max,
+                    num_points=sample_frequency,
+                )
+                * dot_prod_scale
+            )
+
+            barchart = BarChart(
+                values=[cos_dot_prod, sin_dot_prod],
+                y_range=[-20, 20, 10],
+                x_length=1,
+                y_length=3,
+                bar_width=0.3,
+                bar_colors=[REDUCIBLE_GREEN_LIGHTER, REDUCIBLE_ORANGE],
+                y_axis_config={
+                    "label_constructor": CustomLabel,
+                    "font_size": 8,
+                },
+            )
+
+            barchart.scale(2).move_to(RIGHT * 3)
+
+            return barchart
 
         # original signal that will keep changing
         def changing_original_signal():
@@ -1072,6 +1118,7 @@ class SolvingPhaseProblem(MovingCameraScene):
         og_signal_mob = always_redraw(changing_original_signal)
         sin_prod_mob = always_redraw(changing_sin_prod)
         cos_prod_mob = always_redraw(changing_cos_prod)
+        cos_dot_prod = always_redraw(get_dot_prod_cos_bar)
 
         og_t = (
             Text(
@@ -1116,5 +1163,8 @@ class SolvingPhaseProblem(MovingCameraScene):
                 FadeIn, VGroup(*[og_t, af_sine_t, af_cos_t, sin_prod_t, cos_prod_t])
             )
         )
+
+        self.play(FadeIn(cos_dot_prod))
+        self.wait()
 
         self.play(vt_phase.animate.set_value(4 * 2 * PI), run_time=15)

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -633,6 +633,7 @@ class IntroducePhaseProblem(MovingCameraScene):
         print(mt)
 
         self.play(*[FadeOut(mob) for mob in self.mobjects])
+
         rect_scale = 0.8
         rects = VGroup(
             *[

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1291,7 +1291,13 @@ class SolvingPhaseProblem(MovingCameraScene):
 
         def redraw_vector():
             current_coord = arc.get_end()
-            vector = Arrow(np_center, current_coord, buff=0).set_color(REDUCIBLE_YELLOW)
+            vector = Arrow(
+                np_center,
+                current_coord,
+                buff=0,
+                max_tip_length_to_length_ratio=0.1,
+                max_stroke_width_to_length_ratio=2,
+            ).set_color(REDUCIBLE_YELLOW)
             return vector
 
         arc_lines = always_redraw(redraw_arc_coords)
@@ -1308,14 +1314,19 @@ class SolvingPhaseProblem(MovingCameraScene):
             .set_stroke(BLACK, 3, background=True)
         )
         xy_t = (
-            Text("|(x, y)|", font=REDUCIBLE_FONT, weight=BOLD)
+            MathTex("r = \sqrt{x^2 + y^2}")
             .scale(0.5)
-            .set_stroke(BLACK, width=5, background=True)
             .next_to(brace, UP)
+            .scale_to_fit_width(vector.width)
+        )
+        surr_rect = (
+            SurroundingRectangle(xy_t, buff=SMALL_BUFF, color=BLACK, corner_radius=0.1)
+            .set_stroke(width=0)
+            .set_fill(BLACK, opacity=0.7)
         )
 
         self.play(focus_on(frame, vector, buff=7), run_time=3)
-        self.play(FadeIn(xy_t, shift=DOWN * 0.3), Write(brace))
+        self.play(FadeIn(surr_rect, xy_t, shift=DOWN * 0.3), Write(brace))
 
         self.wait()
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1039,7 +1039,6 @@ class SolvingPhaseProblem(MovingCameraScene):
         self.play(vt_phase.animate.set_value(PI / 2))
 
     def capture_sine_and_cosine_transforms(self):
-        original_frequency = 4
         t_max = PI
 
         # samples per second
@@ -1048,80 +1047,84 @@ class SolvingPhaseProblem(MovingCameraScene):
         # total number of samples
         n_samples = sample_frequency
 
-        vt_phase = ValueTracker(0)
-        vt_amplitude = ValueTracker(0.4)
-        vt_frequency = ValueTracker(original_frequency)
-        vt_b = ValueTracker(0)
+        analysis_frequencies = [
+            sample_frequency * m / n_samples for m in range(n_samples // 2)
+        ]
 
+        original_frequency = analysis_frequencies[4]
+
+        # just an array of 5 dots to position the sine waves
         positions = (
             VGroup(*[Dot() for i in range(5)]).arrange(DOWN, buff=1.3).to_edge(LEFT)
         )
 
+        vt_phase = ValueTracker(0)
+
+        scale = 0.4
+
         # original signal that will keep changing
         def changing_original_signal():
             cos_signal = get_cosine_func(
-                amplitude=vt_amplitude.get_value(),
-                phase=vt_phase.get_value(),
-                freq=vt_frequency.get_value(),
-                b=vt_b.get_value(),
+                phase=vt_phase.get_value(), freq=original_frequency
             )
 
-            _, signal_mob = plot_time_domain(
-                cos_signal, 0, t_max=t_max, color=REDUCIBLE_YELLOW
+            signal_axis, signal_mob = plot_time_domain(
+                cos_signal, t_max=t_max, color=REDUCIBLE_YELLOW
             )
 
-            return signal_mob.scale(0.7).move_to(positions[0], aligned_edge=LEFT)
+            vg = VGroup(signal_axis, signal_mob)
+
+            return vg.scale(scale).move_to(positions[0], aligned_edge=LEFT)
 
         def changing_sin_prod():
             og_signal = get_cosine_func(
-                amplitude=vt_amplitude.get_value(),
-                phase=vt_phase.get_value(),
-                freq=vt_frequency.get_value(),
-                b=vt_b.get_value(),
+                phase=vt_phase.get_value(), freq=original_frequency
             )
 
             sin_af = get_sine_func(freq=original_frequency)
 
             prod_f = get_prod_functions(og_signal, sin_af)
 
-            _, sine_prod = plot_time_domain(prod_f, t_max=t_max, color=REDUCIBLE_ORANGE)
-            return sine_prod.scale(0.7).move_to(positions[4], aligned_edge=LEFT)
+            axis, sine_prod = plot_time_domain(
+                prod_f, t_max=t_max, color=REDUCIBLE_ORANGE
+            )
+            vg = VGroup(axis, sine_prod)
+
+            return vg.scale(scale).move_to(positions[4], aligned_edge=LEFT)
 
         def changing_cos_prod():
             og_signal = get_cosine_func(
-                amplitude=vt_amplitude.get_value(),
-                phase=vt_phase.get_value(),
-                freq=vt_frequency.get_value(),
-                b=vt_b.get_value(),
+                phase=vt_phase.get_value(), freq=original_frequency
             )
 
             cos_af = get_cosine_func(freq=original_frequency)
 
             prod_f = get_prod_functions(og_signal, cos_af)
 
-            _, cos_prod = plot_time_domain(
+            axis, cos_prod = plot_time_domain(
                 prod_f, t_max=t_max, color=REDUCIBLE_GREEN_LIGHTER
             )
-            return cos_prod.scale(0.7).move_to(positions[2], aligned_edge=LEFT)
+            vg = VGroup(axis, cos_prod)
+            return vg.scale(scale).move_to(positions[2], aligned_edge=LEFT)
+
+        def changing_sine_dot_prod():
+            pass
 
         # cos based analysis frequency
         _, cos_af = plot_time_domain(
-            get_cosine_func(
-                freq=original_frequency, amplitude=vt_amplitude.get_value()
-            ),
+            get_cosine_func(freq=original_frequency),
             t_max=t_max,
             color=REDUCIBLE_VIOLET,
         )
-        cos_af.scale(0.7).move_to(positions[1], aligned_edge=LEFT)
+        cos_af.scale(scale).move_to(positions[1], aligned_edge=LEFT)
 
         # sin based analysis frequency
         _, sin_af = plot_time_domain(
-            get_sine_func(freq=original_frequency, amplitude=vt_amplitude.get_value()),
+            get_sine_func(freq=original_frequency),
             t_max=t_max,
             color=REDUCIBLE_CHARM,
         )
-
-        sin_af.scale(0.7).move_to(positions[3], aligned_edge=LEFT)
+        sin_af.scale(scale).move_to(positions[3], aligned_edge=LEFT)
 
         og_signal_mob = always_redraw(changing_original_signal)
         sin_prod_mob = always_redraw(changing_sin_prod)
@@ -1133,4 +1136,4 @@ class SolvingPhaseProblem(MovingCameraScene):
         self.play(Write(sin_af))
         self.play(Write(sin_prod_mob))
 
-        self.play(vt_phase.animate.set_value(2 * 4 * PI), run_time=4)
+        self.play(vt_phase.animate.set_value(8 * 2 * PI), run_time=4, rate_func=linear)

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1917,19 +1917,6 @@ class InterpretDFT(MovingCameraScene):
         vt_phase = ValueTracker(0)
         vt_amplitude = ValueTracker(0.3)
 
-        def main_signal_redraw():
-            cos_func = get_cosine_func(
-                freq=vt_frequency.get_value(),
-                amplitude=vt_amplitude.get_value(),
-                phase=vt_phase.get_value(),
-            )
-            _, main_signal_mob = plot_time_domain(cos_func, t_max=t_max)
-            main_signal_mob.scale_to_fit_width(main_signal_vector.width).next_to(
-                main_signal_vector, UP
-            )
-
-            return main_signal_mob
-
         def dft_barchart_redraw():
             cos_func = get_cosine_func(
                 freq=vt_frequency.get_value(),
@@ -1950,13 +1937,74 @@ class InterpretDFT(MovingCameraScene):
                 .next_to(dft_matrix_tex, RIGHT, buff=0.4)
             )
 
+        shift_mobs = RIGHT * 0.7
+        _aux_complex_plane = number_plane.copy().shift(shift_mobs)
+        self.play(
+            focus_on(frame, (indices, _aux_complex_plane)),
+            main_signal_mob.animate.shift(shift_mobs),
+            main_signal_vector.animate.shift(shift_mobs),
+            dot_product.animate.shift(shift_mobs),
+            equal_sign.animate.shift(shift_mobs),
+            number_plane.animate.shift(shift_mobs),
+            complex_circle.animate.shift(shift_mobs),
+            FadeOut(current_dot),
+        )
+
+        def main_signal_redraw():
+            cos_func = get_cosine_func(
+                freq=vt_frequency.get_value(),
+                amplitude=vt_amplitude.get_value(),
+                phase=vt_phase.get_value(),
+            )
+            axis_and_signal = VGroup(*plot_time_domain(cos_func, t_max=t_max))
+            axis_and_signal[0].set_opacity(0.3)
+            axis_and_signal.scale_to_fit_width(main_signal_vector.width).next_to(
+                main_signal_vector, UP
+            )
+
+            return axis_and_signal
+
+        def tracking_text_redraw():
+
+            v_freq = f"{vt_frequency.get_value():.2f}"
+            v_amplitude = f"{vt_amplitude.get_value():.2f}"
+            v_phase = f"{degrees(vt_phase.get_value()) % 360:.2f}"
+
+            tex_frequency = Text(
+                "ƒ = " + v_freq + " Hz",
+                font=REDUCIBLE_FONT,
+                t2f={v_freq: REDUCIBLE_MONO},
+            ).scale(0.8)
+
+            phi_eq = MathTex(r"\phi = ")
+            tex_phase_n = Text(
+                v_phase + "º",
+                font=REDUCIBLE_FONT,
+                t2f={v_phase: REDUCIBLE_MONO},
+            ).scale(0.8)
+            tex_phase = VGroup(phi_eq, tex_phase_n).arrange(RIGHT)
+
+            tex_amplitude = Text(
+                "A = " + v_amplitude,
+                font=REDUCIBLE_FONT,
+                t2f={v_amplitude: REDUCIBLE_MONO},
+            ).scale(0.8)
+
+            return (
+                VGroup(tex_frequency, tex_phase, tex_amplitude)
+                .arrange(DOWN, aligned_edge=LEFT)
+                .next_to(main_signal_mob, UP, buff=0.4)
+            ).scale(0.7)
+
+        tracking_text_changing = always_redraw(tracking_text_redraw)
         main_signal_mob_changing = always_redraw(main_signal_redraw)
         dft_barchart_changing = always_redraw(dft_barchart_redraw)
 
         self.play(
             FadeOut(main_signal_mob),
-            FadeIn(main_signal_mob_changing),
+            Write(main_signal_mob_changing),
             FadeIn(dft_barchart_changing),
+            FadeIn(tracking_text_changing),
             *[indices[idx].animate.set_opacity(1) for idx in range(n_samples)],
             *[
                 sin_af_matrix[idx][1].animate.set_stroke(opacity=1)
@@ -1976,12 +2024,12 @@ class InterpretDFT(MovingCameraScene):
             ],
         )
         self.wait()
-        self.play(vt_phase.animate.set_value(PI / 2))
+        self.play(vt_phase.animate.set_value(4 * 2 * PI), run_time=5)
         self.wait()
-        self.play(vt_frequency.animate.set_value(analysis_frequencies[0]))
+        self.play(vt_frequency.animate.set_value(analysis_frequencies[0]), run_time=5)
         self.wait()
-        self.play(vt_frequency.animate.set_value(analysis_frequencies[1]))
+        self.play(vt_frequency.animate.set_value(analysis_frequencies[1]), run_time=5)
         self.wait()
-        self.play(vt_frequency.animate.set_value(analysis_frequencies[2]))
+        self.play(vt_frequency.animate.set_value(analysis_frequencies[2]), run_time=5)
         self.wait()
-        self.play(vt_frequency.animate.set_value(analysis_frequencies[3]))
+        self.play(vt_frequency.animate.set_value(analysis_frequencies[3]), run_time=5)

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1579,7 +1579,10 @@ class InterpretDFT(MovingCameraScene):
         omega_definition = MathTex(
             r"\text{where} \ \omega = e ^{-\frac{2 \pi i}{N}}"
         ).next_to(dft_matrix_tex, UP)
+
         self.play(FadeIn(dft_matrix_tex, omega_definition))
+        self.wait()
+        self.play(dft_matrix_tex.animate.move_to(ORIGIN), FadeOut(omega_definition))
 
         af_matrix = VGroup(
             *[
@@ -1587,29 +1590,26 @@ class InterpretDFT(MovingCameraScene):
                     *plot_time_domain(
                         get_cosine_func(freq=f, amplitude=0.2), t_max=t_max
                     )
-                )
-                for f in analysis_frequencies
+                ).move_to(dft_matrix_tex[0][i * n_samples], aligned_edge=LEFT)
+                for i, f in enumerate(analysis_frequencies)
             ]
-        ).arrange(DOWN, buff=-2.2)
-
-        af_matrix_signals = (
-            VGroup(
-                *[
-                    VGroup(
-                        af[1].set_color(REDUCIBLE_VIOLET),
-                    )
-                    for af in af_matrix
-                ]
-            )
-            .next_to(ORIGIN, ORIGIN, aligned_edge=UP)
-            .shift(UP * 2)
         )
-
         [af[0].set_opacity(0) for af in af_matrix]
 
-        self.play(LaggedStartMap(FadeIn, af_matrix_signals))
-        self.wait()
-        self.play(af_matrix.animate.scale(0.4).to_edge(RIGHT, buff=1))
+        self.play(FadeIn(af_matrix))
+
+        # af_matrix_signals = (
+        #     VGroup(
+        #         *[
+        #             VGroup(
+        #                 af[1].set_color(REDUCIBLE_VIOLET),
+        #             )
+        #             for af in af_matrix
+        #         ]
+        #     )
+        #     .next_to(ORIGIN, ORIGIN, aligned_edge=UP)
+        #     .shift(UP * 2)
+        # )
 
         sampled_points_af = VGroup(
             *[
@@ -1643,7 +1643,7 @@ class InterpretDFT(MovingCameraScene):
             .move_to(number_plane.c2p(0, 0))
         )
 
-        signals_and_dots = VGroup(af_matrix_signals, sampled_points_af)
+        # signals_and_dots = VGroup(af_matrix_signals, sampled_points_af)
 
         self.play(Write(number_plane), Write(complex_circle))
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1537,3 +1537,44 @@ class SolvingPhaseProblem(MovingCameraScene):
         )
 
         return VGroup(*mobs)
+
+
+class InterpretDFT(MovingCameraScene):
+    def construct(self):
+        reset_frame = self.camera.frame.save_state()
+
+        self.visualize_complex_and_frequencies()
+
+    def visualize_complex_and_frequencies(self):
+        frame = self.camera.frame
+        t_max = PI
+
+        # samples per second
+        sample_frequency = 40
+
+        # total number of samples
+        n_samples = sample_frequency
+
+        analysis_frequencies = [
+            sample_frequency * m / n_samples for m in range(n_samples // 2)
+        ]
+
+        af_matrix = VGroup(
+            *[
+                VGroup(
+                    *plot_time_domain(
+                        get_cosine_func(freq=f, amplitude=0.2), t_max=t_max
+                    )
+                )
+                for f in analysis_frequencies[:7]
+            ]
+        ).arrange(DOWN, buff=-2.2)
+
+        af_matrix_signals = VGroup(*[af[1] for af in af_matrix])
+        self.play(FadeIn(af_matrix_signals))
+
+        sampled_points_af = VGroup(
+            *[get_sampled_dots(signal, axis, x_max=t_max) for axis, signal in af_matrix]
+        )
+
+        self.play(FadeIn(sampled_points_af))

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -977,9 +977,10 @@ class SolvingPhaseProblem(MovingCameraScene):
 
         self.play(FadeIn(changing_signal))
         self.play(FadeOut(sin_mob))
-
         self.wait()
+
         self.play(vt_phase.animate.set_value(PI / 2))
+        self.wait()
 
     def capture_sine_and_cosine_transforms(self):
         t_max = PI

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -769,7 +769,7 @@ class IntroducePhaseProblem(MovingCameraScene):
         ]
 
         # let's just take one AF as an example
-        original_freq = analysis_frequencies[1]
+        original_freq = analysis_frequencies[2]
 
         vt_frequency = ValueTracker(original_freq)
         # this tracker will move phase: from 0 to PI/2
@@ -827,6 +827,13 @@ class IntroducePhaseProblem(MovingCameraScene):
             changing_signal = display_signal(phase_ch_cos)
             return changing_signal.scale(0.6).shift(UP)
 
+        af_matrix = get_analysis_frequency_matrix(
+            N=n_samples,
+            sample_rate=sample_frequency,
+            func="cos",
+            t_max=t_max,
+        )
+
         def updating_transform_redraw():
             signal_function = get_cosine_func(
                 amplitude=vt_amplitude.get_value(),
@@ -835,9 +842,14 @@ class IntroducePhaseProblem(MovingCameraScene):
                 b=vt_b.get_value(),
             )
 
-            rects = get_fourier_rects(
-                signal_function, n_samples, sample_frequency, t_max=t_max
-            )
+            sampled_signal = np.array(
+                [
+                    signal_function(v)
+                    for v in np.linspace(t_min, t_max, num=n_samples, endpoint=False)
+                ]
+            ).reshape(-1, 1)
+
+            rects = get_rectangles_for_matrix_transform(sampled_signal, af_matrix)
 
             return rects.move_to(DOWN * 3.5, aligned_edge=DOWN)
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -765,11 +765,11 @@ class IntroducePhaseProblem(MovingCameraScene):
         n_samples = sample_frequency
 
         analysis_frequencies = [
-            sample_frequency * m / n_samples for m in range(n_samples // 2)
+            sample_frequency * m / n_samples for m in range(n_samples)
         ]
 
         # let's just take one AF as an example
-        original_freq = analysis_frequencies[2]
+        original_freq = analysis_frequencies[1]
 
         vt_frequency = ValueTracker(original_freq)
         # this tracker will move phase: from 0 to PI/2

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -877,18 +877,18 @@ class SolvingPhaseProblem(MovingCameraScene):
     def construct(self):
         reset_frame = self.camera.frame.save_state()
 
-        # self.hacky_sine_waves()
+        self.hacky_sine_waves()
 
-        # self.play(*[FadeOut(mob) for mob in self.mobjects])
-        # self.play(Restore(reset_frame))
+        self.play(*[FadeOut(mob) for mob in self.mobjects])
+        self.play(Restore(reset_frame))
 
-        # self.capture_sine_and_cosine_transforms()
-        # self.play(*[FadeOut(mob) for mob in self.mobjects])
-        # self.play(Restore(reset_frame))
+        self.capture_sine_and_cosine_transforms()
+        self.play(*[FadeOut(mob) for mob in self.mobjects])
+        self.play(Restore(reset_frame))
 
-        # self.sum_up_dft()
-        # self.play(*[FadeOut(mob) for mob in self.mobjects])
-        # self.play(Restore(reset_frame))
+        self.sum_up_dft()
+        self.play(*[FadeOut(mob) for mob in self.mobjects])
+        self.play(Restore(reset_frame))
 
         self.final_tests_dft()
 
@@ -1518,6 +1518,8 @@ class SolvingPhaseProblem(MovingCameraScene):
         self.play(
             vt_phase.animate.set_value(20 * PI / 2), run_time=10, rate_func=linear
         )
+
+        self.wait()
 
     # local utils
     def get_analysis_matrix_mob(self, analysis_frequencies, func="cos", t_max=2 * PI):

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1748,8 +1748,39 @@ class InterpretDFT(MovingCameraScene):
                 ]
             )
             self.play(
-                LaggedStartMap(FadeIn, sampled_points[0]),
-                LaggedStartMap(FadeIn, sampled_points[1]),
+                # enable current index
+                indices[i].animate.set_opacity(1),
+                cos_af_matrix[i][1].animate.set_stroke(opacity=1),
+                *[
+                    cos_af_matrix[idx][1].animate.set_stroke(opacity=0.3)
+                    for idx in range(n_samples)
+                    if idx != i
+                ],
+                sin_af_matrix[i][1].animate.set_stroke(opacity=1),
+                *[
+                    sin_af_matrix[idx][1].animate.set_stroke(opacity=0.3)
+                    for idx in range(n_samples)
+                    if idx != i
+                ],
+                # "disable" every other index
+                *[
+                    indices[idx].animate.set_opacity(0.3)
+                    for idx in range(n_samples)
+                    if idx != i
+                ],
+                *[
+                    sampled_points_cos_af[idx].animate.set_opacity(0.3)
+                    for idx in range(n_samples)
+                    if idx < i
+                ],
+                *[
+                    sampled_points_sin_af[idx].animate.set_opacity(0.3)
+                    for idx in range(n_samples)
+                    if idx < i
+                ],
+                LaggedStartMap(Write, sampled_points[0]),
+                LaggedStartMap(Write, sampled_points[1]),
                 Transform(_points_on_circle, points_on_circle),
+                run_time=0.7,
             )
             self.wait()

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1570,11 +1570,71 @@ class InterpretDFT(MovingCameraScene):
             ]
         ).arrange(DOWN, buff=-2.2)
 
-        af_matrix_signals = VGroup(*[af[1] for af in af_matrix])
-        self.play(FadeIn(af_matrix_signals))
-
-        sampled_points_af = VGroup(
-            *[get_sampled_dots(signal, axis, x_max=t_max) for axis, signal in af_matrix]
+        af_matrix_signals = VGroup(
+            *[
+                VGroup(
+                    af[1].set_color(REDUCIBLE_VIOLET),
+                )
+                for af in af_matrix
+            ]
         )
 
-        self.play(FadeIn(sampled_points_af))
+        [af[0].set_opacity(0) for af in af_matrix]
+
+        self.play(FadeIn(af_matrix_signals))
+        self.play(af_matrix.animate.scale(0.8).to_edge(RIGHT, buff=1))
+
+        sampled_points_af = VGroup(
+            *[
+                get_sampled_dots(signal, axis, x_max=t_max, num_points=5).set_color(
+                    REDUCIBLE_VIOLET
+                )
+                for axis, signal in af_matrix
+            ]
+        )
+
+        number_plane = (
+            NumberPlane(
+                x_length=5,
+                y_length=5,
+                x_range=[-2, 2],
+                y_range=[-2, 2],
+                background_line_style={"stroke_color": REDUCIBLE_VIOLET},
+            )
+            .set_opacity(0.7)
+            .shift(LEFT * 3.4)
+        )
+        np_radius = Line(number_plane.c2p(0, 0), number_plane.c2p(0, 1)).height
+
+        complex_circle = (
+            Circle(np_radius)
+            .set_color(REDUCIBLE_YELLOW)
+            .move_to(number_plane.c2p(0, 0))
+        )
+
+        signals_and_dots = VGroup(af_matrix_signals, sampled_points_af)
+
+        self.play(Write(number_plane), Write(complex_circle))
+
+        _points_on_circle = (
+            Dot()
+            .set_color(REDUCIBLE_YELLOW)
+            .move_to(complex_circle.point_from_proportion(0))
+        )
+        for i, sampled_points in enumerate(sampled_points_af):
+
+            if i == 0:
+                self.play(FadeIn(sampled_points))
+                continue
+
+            n_points = len(sampled_points)
+            points_on_circle = VGroup(
+                *[
+                    Dot()
+                    .move_to(complex_circle.point_from_proportion(n / i))
+                    .set_color(REDUCIBLE_YELLOW)
+                    for n in range(i)
+                ]
+            )
+            self.play(FadeIn(sampled_points))
+            self.play(Transform(_points_on_circle, points_on_circle))

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1580,9 +1580,20 @@ class InterpretDFT(MovingCameraScene):
             r"\text{where} \ \omega = e ^{-\frac{2 \pi i}{N}}"
         ).next_to(dft_matrix_tex, UP)
 
-        self.play(FadeIn(dft_matrix_tex, omega_definition))
+        title = (
+            Text("The DFT Matrix", font=REDUCIBLE_FONT, weight=BOLD)
+            .scale(0.8)
+            .to_edge(UP)
+        )
+        self.play(FadeIn(title, shift=UP * 0.3))
+        self.play(FadeIn(dft_matrix_tex, shift=UP * 0.3))
+        self.play(FadeIn(omega_definition, shift=UP * 0.3))
         self.wait()
-        self.play(dft_matrix_tex.animate.move_to(ORIGIN), FadeOut(omega_definition))
+        self.play(
+            dft_matrix_tex.animate.move_to(ORIGIN).shift(DOWN * 0.5),
+            FadeOut(omega_definition, shift=UP * 0.3),
+        )
+        self.wait()
 
         cos_af_matrix = VGroup(
             *[
@@ -1639,7 +1650,11 @@ class InterpretDFT(MovingCameraScene):
             .next_to(dft_matrix_tex, LEFT, aligned_edge=UP)
         )
 
-        self.play(FadeIn(legend), focus_on(frame, VGroup(dft_matrix_tex, legend)))
+        self.play(
+            FadeIn(legend, shift=UP * 0.3),
+            FadeOut(title, shift=UP * 0.3),
+            focus_on(frame, VGroup(dft_matrix_tex, legend)),
+        )
         self.wait()
 
         sampled_points_cos_af = VGroup(
@@ -1686,14 +1701,31 @@ class InterpretDFT(MovingCameraScene):
             .move_to(number_plane.c2p(0, 0))
         )
 
+        indices = VGroup(
+            *[
+                Text(str(f), font=REDUCIBLE_MONO)
+                .scale(0.7)
+                .next_to(cos_af_matrix[f][0], LEFT)
+                for f in range(n_samples)
+            ]
+        ).next_to(dft_matrix_tex, LEFT, buff=0.5)
+        m_t = (
+            Text("m", font=REDUCIBLE_FONT, weight=BOLD, slant=ITALIC)
+            .scale(0.7)
+            .next_to(indices, UP, buff=0.6)
+        )
+
         self.play(
             FadeOut(legend),
-            focus_on(frame, VGroup(number_plane, dft_matrix_tex)),
+            FadeIn(indices, m_t),
+            focus_on(frame, VGroup(number_plane, indices, dft_matrix_tex)),
         )
+        self.wait()
         self.play(
             Write(number_plane),
             Write(complex_circle),
         )
+        self.wait()
 
         _points_on_circle = (
             Dot()
@@ -1720,3 +1752,4 @@ class InterpretDFT(MovingCameraScene):
                 LaggedStartMap(FadeIn, sampled_points[1]),
                 Transform(_points_on_circle, points_on_circle),
             )
+            self.wait()

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1592,7 +1592,7 @@ class InterpretDFT(MovingCameraScene):
         self.play(FadeIn(omega_definition, shift=UP * 0.3))
         self.wait()
         self.play(
-            dft_matrix_tex.animate.move_to(ORIGIN).shift(DOWN * 0.5),
+            dft_matrix_tex.animate.scale(0.8).move_to(ORIGIN).shift(DOWN * 0.5),
             FadeOut(omega_definition, shift=UP * 0.3),
         )
         self.wait()
@@ -1601,7 +1601,7 @@ class InterpretDFT(MovingCameraScene):
             *[
                 VGroup(
                     *plot_time_domain(
-                        get_cosine_func(freq=f, amplitude=0.2), t_max=t_max
+                        get_cosine_func(freq=f, amplitude=0.13), t_max=t_max
                     )
                 )
                 .stretch_to_fit_width(dft_matrix_tex[0].width)
@@ -1613,7 +1613,9 @@ class InterpretDFT(MovingCameraScene):
         sin_af_matrix = VGroup(
             *[
                 VGroup(
-                    *plot_time_domain(get_sine_func(freq=f, amplitude=0.2), t_max=t_max)
+                    *plot_time_domain(
+                        get_sine_func(freq=f, amplitude=0.13), t_max=t_max
+                    )
                 )
                 .stretch_to_fit_width(dft_matrix_tex[0].width)
                 .move_to(dft_matrix_tex[0][i * n_samples], aligned_edge=LEFT)
@@ -2006,16 +2008,49 @@ class InterpretDFT(MovingCameraScene):
             return (
                 VGroup(tex_frequency, tex_phase, tex_amplitude)
                 .arrange(DOWN, aligned_edge=LEFT)
-                .next_to(main_signal_vector, UP, buff=0.4)
+                .next_to(
+                    main_signal_vector,
+                    UP,
+                    buff=0.4,
+                )
             ).scale(0.7)
+
+        def complex_frequencies_on_plane():
+            cos_func = get_cosine_func(
+                freq=vt_frequency.get_value(),
+                amplitude=vt_amplitude.get_value(),
+                phase=vt_phase.get_value(),
+            )
+
+            sampled_signal = np.array(
+                [
+                    cos_func(f)
+                    for f in np.linspace(0, t_max, num=n_samples, endpoint=False)
+                ]
+            ).reshape(-1, 1)
+
+            dft_on_signal = np.fft.fft2(sampled_signal)
+
+            complex_points = VGroup(
+                *[
+                    LabeledDot(str(i), label_color=WHITE).move_to(
+                        number_plane.n2p(point)
+                    )
+                    for i, point in list(enumerate(dft_on_signal))[::-1]
+                ]
+            )
+
+            return complex_points
 
         tracking_text_changing = always_redraw(tracking_text_redraw)
         main_signal_mob_changing = always_redraw(main_signal_redraw)
         dft_barchart_changing = always_redraw(dft_barchart_redraw)
+        complex_points = always_redraw(complex_frequencies_on_plane)
 
         self.play(
             FadeOut(sampled_dots_main_signal),
             FadeOut(og_axis_and_signal[1]),
+            FadeIn(complex_points),
             FadeIn(main_signal_mob_changing),
             FadeIn(dft_barchart_changing),
             FadeIn(tracking_text_changing),

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -877,20 +877,20 @@ class SolvingPhaseProblem(MovingCameraScene):
     def construct(self):
         reset_frame = self.camera.frame.save_state()
 
-        self.hacky_sine_waves()
+        # self.hacky_sine_waves()
 
-        self.play(*[FadeOut(mob) for mob in self.mobjects])
-        self.play(Restore(reset_frame))
+        # self.play(*[FadeOut(mob) for mob in self.mobjects])
+        # self.play(Restore(reset_frame))
 
         self.capture_sine_and_cosine_transforms()
         self.play(*[FadeOut(mob) for mob in self.mobjects])
         self.play(Restore(reset_frame))
 
-        self.sum_up_dft()
-        self.play(*[FadeOut(mob) for mob in self.mobjects])
-        self.play(Restore(reset_frame))
+        # self.sum_up_dft()
+        # self.play(*[FadeOut(mob) for mob in self.mobjects])
+        # self.play(Restore(reset_frame))
 
-        self.final_tests_dft()
+        # self.final_tests_dft()
 
     def hacky_sine_waves(self):
         original_frequency = 4
@@ -1255,11 +1255,12 @@ class SolvingPhaseProblem(MovingCameraScene):
         )
 
         np_center = number_plane.c2p(0, 0)
+        vt_phase.set_value(0)
 
         def redraw_arc():
             radius = Line(np_center, number_plane.c2p(1, 0)).width
             return (
-                Arc(radius, angle=vt_phase.get_value())
+                Arc(radius, angle=-vt_phase.get_value())
                 .move_arc_center_to(np_center)
                 .set_color(REDUCIBLE_YELLOW)
             )
@@ -1267,7 +1268,6 @@ class SolvingPhaseProblem(MovingCameraScene):
         arc = always_redraw(redraw_arc)
         arc.move_arc_center_to(np_center)
 
-        vt_phase.set_value(0)
         self.play(Write(number_plane))
         self.play(FadeIn(arc))
         self.play(vt_phase.animate.set_value(2 * PI), run_time=10)

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -579,6 +579,7 @@ class IntroSimilarityConcept(MovingCameraScene):
 class IntroducePhaseProblem(MovingCameraScene):
     def construct(self):
         frame = self.camera.frame
+        t_min = 0
         t_max = TAU * 2
 
         original_freq = 4
@@ -606,16 +607,14 @@ class IntroducePhaseProblem(MovingCameraScene):
         self.play(vt.animate.set_value(PI / 2))
         self.play(vt.animate.set_value(PI))
 
-        af_matrix = get_analysis_frequency_matrix(of_sampling_rate)
+        af_matrix = get_analysis_frequency_matrix(of_sampling_rate, t_max=t_max)
 
-        sampled_signal = (
-            np.array(
-                [
-                    get_cosine_func(freq=original_freq)(n)
-                    for n in range(of_sampling_rate)
-                ]
-            ).reshape(-1, 1),
-        )
+        sampled_signal = np.array(
+            [
+                get_cosine_func(freq=original_freq)(v)
+                for v in np.linspace(t_min, t_max, num=of_sampling_rate, endpoint=False)
+            ]
+        ).reshape(-1, 1)
         mt = apply_matrix_transform(sampled_signal, af_matrix)
 
         print(sampled_signal)

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -583,13 +583,13 @@ class IntroSimilarityConcept(MovingCameraScene):
 class IntroducePhaseProblem(MovingCameraScene):
     def construct(self):
 
-        # frame = self.camera.frame.save_state()
-        # self.try_sine_wave()
+        frame = self.camera.frame.save_state()
+        self.try_sine_wave()
 
         # self.play(*[FadeOut(mob) for mob in self.mobjects])
         # self.play(Restore(frame))
 
-        self.test_cases_again()
+        # self.test_cases_again()
 
     def try_sine_wave(self):
         frame = self.camera.frame
@@ -599,7 +599,7 @@ class IntroducePhaseProblem(MovingCameraScene):
         original_freq = 2
 
         # samples per second
-        sample_frequency = 10
+        sample_frequency = 16
 
         n_samples = sample_frequency
 
@@ -638,9 +638,11 @@ class IntroducePhaseProblem(MovingCameraScene):
                 ]
             ).reshape(-1, 1)
 
-            rects = get_rectangles_for_matrix_transform(sampled_signal, af_matrix)
+            rects = get_fourier_rects_from_custom_matrix(
+                signal_function, af_matrix, n_samples=n_samples, t_max=t_max
+            )
 
-            return rects
+            return rects.move_to(DOWN * 3.5, aligned_edge=DOWN)
 
         changing_sine = always_redraw(sine_cosine_redraw)
         sampled_dots = VGroup(
@@ -739,9 +741,9 @@ class IntroducePhaseProblem(MovingCameraScene):
 
         self.play(
             *[
-                bar.animate.set_color(REDUCIBLE_GREEN)
+                bar.animate.set_color(REDUCIBLE_YELLOW)
                 if prod > 0
-                else bar.animate.set_color(REDUCIBLE_CHARM)
+                else bar.animate.set_color(REDUCIBLE_BLUE)
                 for prod, bar in zip(prod_per_sample, barchart[0])
             ]
         )
@@ -830,7 +832,6 @@ class IntroducePhaseProblem(MovingCameraScene):
         af_matrix = get_analysis_frequency_matrix(
             N=n_samples,
             sample_rate=sample_frequency,
-            func="cos",
             t_max=t_max,
         )
 
@@ -849,7 +850,9 @@ class IntroducePhaseProblem(MovingCameraScene):
                 ]
             ).reshape(-1, 1)
 
-            rects = get_rectangles_for_matrix_transform(sampled_signal, af_matrix)
+            rects = get_fourier_rects_from_custom_matrix(
+                signal_function, af_matrix, n_samples=n_samples, t_max=t_max
+            )
 
             return rects.move_to(DOWN * 3.5, aligned_edge=DOWN)
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -598,7 +598,6 @@ class IntroducePhaseProblem(MovingCameraScene):
         analysis_frequencies = [
             sample_frequency * m / n_samples for m in range(n_samples // 2)
         ]
-        print(analysis_frequencies)
 
         # let's just take one AF as an example
         original_freq = analysis_frequencies[2]
@@ -662,7 +661,6 @@ class IntroducePhaseProblem(MovingCameraScene):
         af_matrix = get_analysis_frequency_matrix(
             N=n_samples, sample_rate=sample_frequency, t_max=t_max
         )
-        print(af_matrix.shape)
 
         rect_scale = 0.1
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1551,7 +1551,7 @@ class InterpretDFT(MovingCameraScene):
         t_max = PI
 
         # samples per second
-        sample_frequency = 4
+        sample_frequency = 8
 
         # total number of samples
         n_samples = sample_frequency
@@ -1575,8 +1575,11 @@ class InterpretDFT(MovingCameraScene):
 
             matrix_elements.append(row)
 
-        matrix = Matrix(matrix_elements)
-        self.play(FadeIn(matrix))
+        dft_matrix_tex = Matrix(matrix_elements).shift(DOWN * 3)
+        omega_definition = MathTex(
+            r"\text{where} \ \omega = e ^{-\frac{2 \pi i}{N}}"
+        ).next_to(dft_matrix_tex, UP)
+        self.play(FadeIn(dft_matrix_tex, omega_definition))
 
         af_matrix = VGroup(
             *[

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1873,7 +1873,9 @@ class InterpretDFT(MovingCameraScene):
         for i in range(n_samples):
             point = dft_on_signal[i]
 
-            _current_dot = LabeledDot(i).move_to(number_plane.n2p(point))
+            _current_dot = LabeledDot(i, label_color=WHITE).move_to(
+                number_plane.n2p(point)
+            )
 
             self.play(
                 Transform(current_dot, _current_dot),
@@ -2073,12 +2075,32 @@ class InterpretDFT(MovingCameraScene):
             ],
         )
         self.wait()
-        self.play(vt_phase.animate.set_value(4 * 2 * PI), run_time=5)
+        self.play(
+            vt_phase.animate.set_value(4 * 2 * PI),
+            run_time=10,
+            rate_func=rate_functions.ease_in_out_sine,
+        )
         self.wait()
-        self.play(vt_frequency.animate.set_value(analysis_frequencies[0]), run_time=5)
+        self.play(
+            vt_frequency.animate.set_value(analysis_frequencies[0]),
+            run_time=5,
+            rate_func=rate_functions.ease_in_out_sine,
+        )
         self.wait()
-        self.play(vt_frequency.animate.set_value(analysis_frequencies[1]), run_time=5)
+        self.play(
+            vt_frequency.animate.set_value(analysis_frequencies[1]),
+            run_time=5,
+            rate_func=rate_functions.ease_in_out_sine,
+        )
         self.wait()
-        self.play(vt_frequency.animate.set_value(analysis_frequencies[2]), run_time=5)
+        self.play(
+            vt_frequency.animate.set_value(analysis_frequencies[2]),
+            run_time=5,
+            rate_func=rate_functions.ease_in_out_sine,
+        )
         self.wait()
-        self.play(vt_frequency.animate.set_value(analysis_frequencies[3]), run_time=5)
+        self.play(
+            vt_frequency.animate.set_value(analysis_frequencies[3]),
+            run_time=5,
+            rate_func=rate_functions.ease_in_out_sine,
+        )

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1559,6 +1559,7 @@ class InterpretDFT(MovingCameraScene):
         analysis_frequencies = [
             sample_frequency * m / n_samples for m in range(n_samples)
         ]
+        original_frequency = analysis_frequencies[2]
 
         matrix_elements = []
         power = 0
@@ -1741,14 +1742,14 @@ class InterpretDFT(MovingCameraScene):
 
             points_on_circle = VGroup(
                 *[
-                    Dot(radius=DEFAULT_DOT_RADIUS * 1)
+                    Dot(radius=DEFAULT_DOT_RADIUS * 1.4)
                     .move_to(complex_circle.point_from_proportion(n / i))
                     .set_color(REDUCIBLE_YELLOW)
                     for n in range(i)
                 ]
             )
             self.play(
-                # enable current index
+                # enable current index: number, sine and cosine graphs and sampled dots
                 indices[i].animate.set_opacity(1),
                 cos_af_matrix[i][1].animate.set_stroke(opacity=1),
                 *[
@@ -1784,3 +1785,13 @@ class InterpretDFT(MovingCameraScene):
                 run_time=0.7,
             )
             self.wait()
+
+        _, main_signal = plot_time_domain(
+            get_cosine_func(freq=original_frequency), t_max=t_max
+        )
+
+        main_signal.rotate(90)
+        main_signal = Matrix(
+            [[Dot().set_color(REDUCIBLE_YELLOW)] for n in range(n_samples)]
+        ).next_to(number_plane, RIGHT)
+        self.play(FadeIn(main_signal), focus_on(frame, main_signal))

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -583,10 +583,10 @@ class IntroducePhaseProblem(MovingCameraScene):
         frame = self.camera.frame.save_state()
         self.try_sine_wave()
 
-        # self.play(*[FadeOut(mob) for mob in self.mobjects])
-        # self.play(Restore(frame))
+        self.play(*[FadeOut(mob) for mob in self.mobjects])
+        self.play(Restore(frame))
 
-        # self.test_cases_again()
+        self.test_cases_again()
 
     def try_sine_wave(self):
         frame = self.camera.frame

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -574,3 +574,24 @@ class IntroSimilarityConcept(MovingCameraScene):
         self.play(Write(original_freq_mob))
         self.play(FadeIn(times))
         self.play(LaggedStartMap(FadeIn, analysis_freqs), run_time=2)
+
+
+class IntroducePhaseProblem(MovingCameraScene):
+    def construct(self):
+        frame = self.camera.frame
+        t_max = TAU * 2
+
+        original_freq = 2
+
+        cos_og = get_cosine_func(freq=original_freq, amplitude=0.3)
+
+        sin_og = get_sine_func(freq=original_freq, amplitude=0.3)
+
+        cos_axes, cos_mob = plot_time_domain(cos_og, t_max=t_max)
+        sin_axes, sin_mob = plot_time_domain(sin_og, t_max=t_max)
+
+        self.play(Write(cos_mob), Write(cos_axes))
+
+        self.wait()
+
+        self.play(Transform(cos_mob, sin_mob))

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -583,11 +583,11 @@ class IntroSimilarityConcept(MovingCameraScene):
 class IntroducePhaseProblem(MovingCameraScene):
     def construct(self):
 
-        frame = self.camera.frame.save_state()
-        self.try_sine_wave()
+        # frame = self.camera.frame.save_state()
+        # self.try_sine_wave()
 
-        self.play(*[FadeOut(mob) for mob in self.mobjects])
-        self.play(Restore(frame))
+        # self.play(*[FadeOut(mob) for mob in self.mobjects])
+        # self.play(Restore(frame))
 
         self.test_cases_again()
 
@@ -759,7 +759,7 @@ class IntroducePhaseProblem(MovingCameraScene):
         t_max = TAU * 2
 
         # samples per second
-        sample_frequency = 40
+        sample_frequency = 16
 
         # total number of samples
         n_samples = sample_frequency
@@ -824,14 +824,8 @@ class IntroducePhaseProblem(MovingCameraScene):
                 phase=vt_phase.get_value(),
                 b=vt_b.get_value(),
             )
-            _, phase_ch_cos_mob = plot_time_domain(phase_ch_cos, t_max=t_max)
-            return phase_ch_cos_mob.scale(0.6).shift(UP)
-
-        af_matrix = get_analysis_frequency_matrix(
-            N=n_samples, sample_rate=sample_frequency, t_max=t_max
-        )
-
-        rect_scale = 0.1
+            changing_signal = display_signal(phase_ch_cos)
+            return changing_signal.scale(0.6).shift(UP)
 
         def updating_transform_redraw():
             signal_function = get_cosine_func(
@@ -841,57 +835,77 @@ class IntroducePhaseProblem(MovingCameraScene):
                 b=vt_b.get_value(),
             )
 
-            sampled_signal = np.array(
-                [
-                    signal_function(v)
-                    for v in np.linspace(t_min, t_max, num=n_samples, endpoint=False)
-                ]
-            ).reshape(-1, 1)
+            rects = get_fourier_rects(
+                signal_function, n_samples, sample_frequency, t_max=t_max
+            )
 
-            rects = get_rectangles_for_matrix_transform(sampled_signal, af_matrix)
-
-            return rects
+            return rects.move_to(DOWN * 3.5, aligned_edge=DOWN)
 
         changing_signal_mob = always_redraw(change_phase_redraw)
         freq_analysis = always_redraw(updating_transform_redraw)
         changing_tex_group = always_redraw(change_text_redraw)
 
-        line_ref = DashedVMobject(
-            Line(freq_analysis.get_left(), freq_analysis.get_right())
-            .set_stroke(WHITE, opacity=0.5)
-            .move_to(changing_signal_mob)
-        )
-
-        self.play(Write(changing_signal_mob), FadeIn(freq_analysis), Write(line_ref))
+        self.play(Write(changing_signal_mob), FadeIn(freq_analysis))
         self.play(FadeIn(changing_tex_group))
 
-        self.play(vt_amplitude.animate.set_value(0.5), run_time=0.8)
+        self.play(
+            vt_amplitude.animate.set_value(0.5),
+            run_time=0.8,
+            rate_func=rate_functions.ease_in_out_sine,
+        )
         self.wait()
-        self.play(vt_amplitude.animate.set_value(0.1), run_time=0.8)
+        self.play(
+            vt_amplitude.animate.set_value(0.1),
+            run_time=0.8,
+            rate_func=rate_functions.ease_in_out_sine,
+        )
         self.wait()
-        self.play(vt_amplitude.animate.set_value(0), run_time=0.8)
+        self.play(
+            vt_amplitude.animate.set_value(0),
+            run_time=0.8,
+            rate_func=rate_functions.ease_in_out_sine,
+        )
         self.wait()
-        self.play(vt_amplitude.animate.set_value(1), run_time=0.8)
+        self.play(
+            vt_amplitude.animate.set_value(1),
+            run_time=0.8,
+            rate_func=rate_functions.ease_in_out_sine,
+        )
         self.wait()
 
-        self.play(vt_frequency.animate.set_value(analysis_frequencies[3]))
+        self.play(
+            vt_frequency.animate.set_value(analysis_frequencies[3]),
+            rate_func=rate_functions.ease_in_out_sine,
+        )
         self.wait()
-        self.play(vt_frequency.animate.set_value(analysis_frequencies[4]))
+        self.play(
+            vt_frequency.animate.set_value(analysis_frequencies[4]),
+            rate_func=rate_functions.ease_in_out_sine,
+        )
         self.wait()
 
-        self.play(vt_b.animate.set_value(0.3))
+        self.play(
+            vt_b.animate.set_value(0.3), rate_func=rate_functions.ease_in_out_sine
+        )
         self.wait()
-        self.play(vt_b.animate.set_value(0.5))
+        self.play(
+            vt_b.animate.set_value(0.5), rate_func=rate_functions.ease_in_out_sine
+        )
         self.wait()
-        self.play(vt_b.animate.set_value(0))
+        self.play(vt_b.animate.set_value(0), rate_func=rate_functions.ease_in_out_sine)
         self.wait()
 
         for i in range(1, 5):
-            self.play(vt_phase.animate.set_value(i * PI / 2))
+            self.play(
+                vt_phase.animate.set_value(i * PI / 2),
+                rate_func=rate_functions.ease_in_out_sine,
+            )
             self.wait()
 
         self.play(
-            vt_phase.animate.set_value(20 * PI / 2), run_time=10, rate_func=linear
+            vt_phase.animate.set_value(20 * PI / 2),
+            run_time=10,
+            rate_func=rate_functions.ease_in_out_sine,
         )
 
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -620,8 +620,6 @@ class IntroducePhaseProblem(MovingCameraScene):
             N=n_samples, sample_rate=sample_frequency, t_max=t_max
         )
 
-        rect_scale = 0.1
-
         def updating_transform_redraw():
             signal_function = get_cosine_func(
                 amplitude=vt_amplitude.get_value(),
@@ -737,12 +735,10 @@ class IntroducePhaseProblem(MovingCameraScene):
         t_max = TAU * 2
 
         # samples per second
-        sample_frequency = 80
+        sample_frequency = 40
 
         # total number of samples
         n_samples = sample_frequency
-
-        duration = n_samples / sample_frequency
 
         analysis_frequencies = [
             sample_frequency * m / n_samples for m in range(n_samples // 2)
@@ -751,8 +747,8 @@ class IntroducePhaseProblem(MovingCameraScene):
         # let's just take one AF as an example
         original_freq = analysis_frequencies[2]
 
-        # this tracker will move phase: from 0 to PI/2
         vt_frequency = ValueTracker(original_freq)
+        # this tracker will move phase: from 0 to PI/2
         vt_phase = ValueTracker(0)
         vt_amplitude = ValueTracker(1)
         vt_b = ValueTracker(0)
@@ -828,25 +824,7 @@ class IntroducePhaseProblem(MovingCameraScene):
                 ]
             ).reshape(-1, 1)
 
-            # matrix transform
-            mt = apply_matrix_transform(sampled_signal, af_matrix)
-
-            rects = (
-                VGroup(
-                    *[
-                        VGroup(
-                            Rectangle(
-                                color=REDUCIBLE_VIOLET, width=0.3, height=f * rect_scale
-                            ).set_fill(REDUCIBLE_VIOLET, opacity=1),
-                            Text(str(i), font=REDUCIBLE_MONO).scale(0.4),
-                        ).arrange(DOWN)
-                        for i, f in enumerate(mt.flatten()[: mt.shape[0] // 2])
-                    ]
-                )
-                .arrange(RIGHT, aligned_edge=DOWN)
-                .scale(0.6)
-                .move_to(DOWN * 3.4, aligned_edge=DOWN)
-            )
+            rects = get_rectangles_for_matrix_transform(sampled_signal, af_matrix)
 
             return rects
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1479,7 +1479,10 @@ class SolvingPhaseProblem(MovingCameraScene):
             return text_group
 
         def changing_signal_redraw():
-            amplitude_padding = 0.4
+            # for viz purposes, we are going to make the signal's amplitude smaller
+            # all the calculations will be done with the actual amplitude, though
+            # this helps the redrawing function deal better with the signal
+            amplitude_padding = 0.2
             changing_func = get_cosine_func(
                 amplitude=vt_amplitude.get_value() - amplitude_padding
                 if vt_amplitude.get_value() > amplitude_padding

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -689,23 +689,25 @@ class IntroducePhaseProblem(MovingCameraScene):
         )
 
         cos_mob = changing_sine.copy()
-        self.play(FadeIn(cos_mob), FadeOut(changing_sine))
-        self.play(
-            FadeOut(changing_rects),
-            FadeOut(sin_tex),
-            cos_mob.animate.move_to(ORIGIN),
-        )
-        self.wait()
-
         analysis_freq = get_cosine_func(freq=original_freq)
         _, analysis_freq_mob = plot_time_domain(analysis_freq, t_max=t_max)
 
         analysis_freq_mob.set_color(REDUCIBLE_VIOLET).scale_to_fit_width(
             changing_sine.width
-        ).move_to(cos_mob)
+        ).move_to(ORIGIN)
 
-        self.play(Write(analysis_freq_mob), frame.animate.scale(0.7).shift(DOWN * 0.8))
+        self.play(FadeIn(cos_mob), FadeOut(changing_sine))
+        self.play(
+            FadeOut(changing_rects),
+            FadeOut(sin_tex),
+            cos_mob.animate.move_to(ORIGIN),
+            Write(analysis_freq_mob),
+            frame.animate.scale(0.8).shift(DOWN * 0.8),
+        )
         self.wait()
+
+        # self.play(Write(analysis_freq_mob), frame.animate.scale(0.7).shift(DOWN * 0.8))
+        # self.wait()
 
         aux_analysis_freq_axis, _ = plot_time_domain(
             get_cosine_func(freq=original_freq), t_max=t_max
@@ -721,17 +723,25 @@ class IntroducePhaseProblem(MovingCameraScene):
 
         dots_analysis_freq = get_sampled_dots(
             analysis_freq_mob, aux_analysis_freq_axis, num_points=10
-        )
-        dots_cos_mob = get_sampled_dots(sine_wave, aux_signal_axis, num_points=10)
+        ).set_fill(REDUCIBLE_VIOLET)
+        dots_cos_mob = get_sampled_dots(
+            sine_wave, aux_signal_axis, num_points=10
+        ).set_fill(REDUCIBLE_YELLOW)
 
-        self.play(LaggedStartMap(FadeIn, [*dots_analysis_freq, dots_cos_mob]))
+        self.play(LaggedStartMap(FadeIn, [*dots_analysis_freq, *dots_cos_mob]))
 
         dots_line = dots_cos_mob.copy()
-        [d.move_to(DOWN * 2, coor_mask=[0, 1, 0]) for d in dots_line]
+        [
+            d.set_fill(REDUCIBLE_GREEN_LIGHTER, opacity=1).move_to(
+                DOWN * 2.5, coor_mask=[0, 1, 0]
+            )
+            for d in dots_line
+        ]
 
         self.play(
             Transform(dots_cos_mob, dots_line), Transform(dots_analysis_freq, dots_line)
         )
+        self.wait()
 
         zero = (
             Text(str(0), font=REDUCIBLE_MONO, weight=SEMIBOLD)
@@ -739,10 +749,8 @@ class IntroducePhaseProblem(MovingCameraScene):
             .move_to(dots_cos_mob)
         )
 
-        self.play(
-            Transform(dots_cos_mob, zero),
-            Transform(dots_analysis_freq, zero),
-        )
+        self.play(Transform(dots_cos_mob, zero), FadeOut(dots_analysis_freq))
+        self.wait()
 
     def test_cases_again(self):
         frame = self.camera.frame

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -606,7 +606,7 @@ class IntroducePhaseProblem(MovingCameraScene):
         self.play(vt.animate.set_value(PI / 2))
         self.play(vt.animate.set_value(PI))
 
-        af_matrix = self.analysis_frequency_matrix(of_sampling_rate)
+        af_matrix = get_analysis_frequency_matrix(of_sampling_rate)
 
         sampled_signal = (
             np.array(
@@ -635,13 +635,3 @@ class IntroducePhaseProblem(MovingCameraScene):
             ]
         ).arrange(RIGHT, aligned_edge=DOWN)
         self.play(Write(rects))
-        fouri
-
-    def analysis_frequency_matrix(self, N):
-        # analysis frequencies
-        af = [get_cosine_func(freq=n) for n in range(N)]
-
-        # for each analysis frequency, sample that function along N points
-        # this returns the frequencies per rows, so .T transposes and
-        # have the signal values in cols
-        return np.array([[f(s) for s in range(N)] for f in af]).T

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -583,10 +583,10 @@ class IntroducePhaseProblem(MovingCameraScene):
         frame = self.camera.frame.save_state()
         self.try_sine_wave()
 
-        self.play(*[FadeOut(mob) for mob in self.mobjects])
-        self.play(Restore(frame))
+        # self.play(*[FadeOut(mob) for mob in self.mobjects])
+        # self.play(Restore(frame))
 
-        self.test_cases_again()
+        # self.test_cases_again()
 
     def try_sine_wave(self):
         frame = self.camera.frame
@@ -637,25 +637,7 @@ class IntroducePhaseProblem(MovingCameraScene):
                 ]
             ).reshape(-1, 1)
 
-            # matrix transform
-            mt = apply_matrix_transform(sampled_signal, af_matrix)
-
-            rects = (
-                VGroup(
-                    *[
-                        VGroup(
-                            Rectangle(
-                                color=REDUCIBLE_VIOLET, width=0.3, height=f * rect_scale
-                            ).set_fill(REDUCIBLE_VIOLET, opacity=1),
-                            Text(str(i), font=REDUCIBLE_MONO).scale(0.4),
-                        ).arrange(DOWN)
-                        for i, f in enumerate(mt.flatten()[: mt.shape[0] // 2])
-                    ]
-                )
-                .arrange(RIGHT, aligned_edge=DOWN)
-                .scale(0.6)
-                .move_to(DOWN * 3.4, aligned_edge=DOWN)
-            )
+            rects = get_rectangles_for_matrix_transform(sampled_signal, af_matrix)
 
             return rects
 
@@ -705,9 +687,6 @@ class IntroducePhaseProblem(MovingCameraScene):
             frame.animate.scale(0.8).shift(DOWN * 0.8),
         )
         self.wait()
-
-        # self.play(Write(analysis_freq_mob), frame.animate.scale(0.7).shift(DOWN * 0.8))
-        # self.wait()
 
         aux_analysis_freq_axis, _ = plot_time_domain(
             get_cosine_func(freq=original_freq), t_max=t_max

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -875,12 +875,12 @@ class IntroducePhaseProblem(MovingCameraScene):
 
 class SolvingPhaseProblem(MovingCameraScene):
     def construct(self):
-        # frame = self.camera.frame.save_state()
+        frame = self.camera.frame.save_state()
 
-        # self.hacky_sine_waves()
+        self.hacky_sine_waves()
 
-        # self.play(*[FadeOut(mob) for mob in self.mobjects])
-        # self.play(Restore(frame))
+        self.play(*[FadeOut(mob) for mob in self.mobjects])
+        self.play(Restore(frame))
 
         self.capture_sine_and_cosine_transforms()
 
@@ -1175,19 +1175,6 @@ class SolvingPhaseProblem(MovingCameraScene):
             rate_func=rate_functions.ease_in_out_sine,
         )
         self.wait()
-
-        # signals_vg = VGroup(
-        #     og_signal_mob,
-        #     cos_af_vg,
-        #     cos_prod_mob,
-        #     sin_af_vg,
-        #     sin_prod_mob,
-        #     og_t,
-        #     af_sine_t,
-        #     af_cos_t,
-        #     sin_prod_t,
-        #     cos_prod_t,
-        # )
 
         cos_dot_prod_mob.clear_updaters()
 

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -583,10 +583,10 @@ class IntroducePhaseProblem(MovingCameraScene):
         frame = self.camera.frame.save_state()
         self.try_sine_wave()
 
-        self.play(*[FadeOut(mob) for mob in self.mobjects])
-        self.play(Restore(frame))
+        # self.play(*[FadeOut(mob) for mob in self.mobjects])
+        # self.play(Restore(frame))
 
-        self.test_cases_again()
+        # self.test_cases_again()
 
     def try_sine_wave(self):
         frame = self.camera.frame
@@ -705,29 +705,50 @@ class IntroducePhaseProblem(MovingCameraScene):
             sine_wave, aux_signal_axis, num_points=10
         ).set_fill(REDUCIBLE_YELLOW)
 
-        self.play(LaggedStartMap(FadeIn, [*dots_analysis_freq, *dots_cos_mob]))
-
-        dots_line = dots_cos_mob.copy()
-        [
-            d.set_fill(REDUCIBLE_GREEN_LIGHTER, opacity=1).move_to(
-                DOWN * 2.5, coor_mask=[0, 1, 0]
-            )
-            for d in dots_line
+        sampled_dots_af = [
+            analysis_freq(v) for v in np.linspace(0, t_max, 10, endpoint=False)
+        ]
+        sampled_dots_signal = [
+            get_cosine_func(freq=original_freq, phase=vt_phase.get_value())(v)
+            for v in np.linspace(0, t_max, 10, endpoint=False)
+        ]
+        prod_per_sample = [
+            af * s for af, s in zip(sampled_dots_af, sampled_dots_signal)
         ]
 
+        self.play(LaggedStartMap(FadeIn, [*dots_analysis_freq, *dots_cos_mob]))
+        self.wait()
+
+        barchart = BarChart(
+            prod_per_sample,
+            bar_colors=[REDUCIBLE_PURPLE],
+            bar_width=1,
+            x_length=dots_analysis_freq.width,
+        )
+        barchart.remove(barchart[2])
+        barchart.stretch_to_fit_width(dots_analysis_freq.width).stretch_to_fit_height(
+            analysis_freq_mob.height * 1.3
+        ).next_to(analysis_freq_mob, DOWN, buff=0.5, aligned_edge=LEFT)
+
+        self.play(Write(barchart[1]))
+        self.play(LaggedStartMap(FadeIn, barchart[0]))
+        self.wait()
+
         self.play(
-            Transform(dots_cos_mob, dots_line), Transform(dots_analysis_freq, dots_line)
+            *[
+                bar.animate.set_color(REDUCIBLE_GREEN)
+                if prod > 0
+                else bar.animate.set_color(REDUCIBLE_CHARM)
+                for prod, bar in zip(prod_per_sample, barchart[0])
+            ]
         )
         self.wait()
 
-        zero = (
-            Text(str(0), font=REDUCIBLE_MONO, weight=SEMIBOLD)
-            .scale(2)
-            .move_to(dots_cos_mob)
+        self.play(
+            barchart.animate.change_bar_values(
+                [0 for i in range(len(prod_per_sample))], update_colors=False
+            )
         )
-
-        self.play(Transform(dots_cos_mob, zero), FadeOut(dots_analysis_freq))
-        self.wait()
 
     def test_cases_again(self):
         frame = self.camera.frame

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1257,6 +1257,7 @@ class SolvingPhaseProblem(MovingCameraScene):
         arc = always_redraw(redraw_arc)
         arc.move_arc_center_to(number_plane.c2p(0, 0))
 
-        self.play(Write(number_plane), vt_phase.animate.set_value(0))
+        vt_phase.set_value(0)
+        self.play(Write(number_plane))
         self.play(FadeIn(arc))
         self.play(vt_phase.animate.set_value(2 * PI), run_time=10)

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1053,9 +1053,21 @@ class SolvingPhaseProblem(MovingCameraScene):
 
         original_frequency = analysis_frequencies[4]
 
+        og_t = Text(
+            f"Original signal, ƒ = {original_frequency:.2f} Hz", font=REDUCIBLE_MONO
+        ).scale(0.6)
+        af_sine_t = Text(f"Analysis frequency, sin(x)", font=REDUCIBLE_MONO).scale(0.6)
+        af_cos_t = Text(f"Analysis frequency, cos(x)", font=REDUCIBLE_MONO).scale(0.6)
+        og_t = Text(f"", font=REDUCIBLE_MONO).scale(0.6)
+        og_t = Text(
+            f"Original signal, ƒ = {original_frequency:.2f} Hz", font=REDUCIBLE_MONO
+        ).scale(0.6)
+
         # just an array of 5 dots to position the sine waves
         positions = (
-            VGroup(*[Dot() for i in range(5)]).arrange(DOWN, buff=1.3).to_edge(LEFT)
+            VGroup(*[Dot() for i in range(5)])
+            .arrange(DOWN, buff=1.3)
+            .to_edge(LEFT, buff=3)
         )
 
         vt_phase = ValueTracker(0)
@@ -1107,33 +1119,32 @@ class SolvingPhaseProblem(MovingCameraScene):
             vg = VGroup(axis, cos_prod)
             return vg.scale(scale).move_to(positions[2], aligned_edge=LEFT)
 
-        def changing_sine_dot_prod():
-            pass
-
         # cos based analysis frequency
-        _, cos_af = plot_time_domain(
+        cos_axis, cos_af = plot_time_domain(
             get_cosine_func(freq=original_frequency),
             t_max=t_max,
             color=REDUCIBLE_VIOLET,
         )
-        cos_af.scale(scale).move_to(positions[1], aligned_edge=LEFT)
+        cos_af_vg = VGroup(cos_axis, cos_af)
+        cos_af_vg.scale(scale).move_to(positions[1], aligned_edge=LEFT)
 
         # sin based analysis frequency
-        _, sin_af = plot_time_domain(
+        sin_axis, sin_af = plot_time_domain(
             get_sine_func(freq=original_frequency),
             t_max=t_max,
             color=REDUCIBLE_CHARM,
         )
-        sin_af.scale(scale).move_to(positions[3], aligned_edge=LEFT)
+        sin_af_vg = VGroup(sin_axis, sin_af)
+        sin_af_vg.scale(scale).move_to(positions[3], aligned_edge=LEFT)
 
         og_signal_mob = always_redraw(changing_original_signal)
         sin_prod_mob = always_redraw(changing_sin_prod)
         cos_prod_mob = always_redraw(changing_cos_prod)
 
         self.play(Write(og_signal_mob))
-        self.play(Write(cos_af))
+        self.play(Write(cos_af_vg))
         self.play(Write(cos_prod_mob))
-        self.play(Write(sin_af))
+        self.play(Write(sin_af_vg))
         self.play(Write(sin_prod_mob))
 
-        self.play(vt_phase.animate.set_value(8 * 2 * PI), run_time=4, rate_func=linear)
+        self.play(vt_phase.animate.set_value(8 * 2 * PI), run_time=15)

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1161,11 +1161,13 @@ class SolvingPhaseProblem(MovingCameraScene):
             .next_to(cos_prod_mob, LEFT)
         )
 
-        self.play(Write(og_signal_mob))
-        self.play(Write(cos_af_vg))
-        self.play(Write(cos_prod_mob))
-        self.play(Write(sin_af_vg))
-        self.play(Write(sin_prod_mob))
+        self.play(
+            Write(og_signal_mob),
+            Write(cos_af_vg),
+            Write(cos_prod_mob),
+            Write(sin_af_vg),
+            Write(sin_prod_mob),
+        )
 
         self.play(
             LaggedStartMap(

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1133,7 +1133,7 @@ class SolvingPhaseProblem(MovingCameraScene):
 
         og_t = (
             Text(
-                f"x[n], ƒ = {original_frequency:.2f} Hz",
+                f"x[n]",
                 font=REDUCIBLE_FONT,
                 weight=BOLD,
             )
@@ -1175,4 +1175,4 @@ class SolvingPhaseProblem(MovingCameraScene):
             )
         )
 
-        self.play(vt_phase.animate.set_value(8 * 2 * PI), run_time=15)
+        self.play(vt_phase.animate.set_value(4 * 2 * PI), run_time=15)

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -582,10 +582,19 @@ class IntroducePhaseProblem(MovingCameraScene):
         t_min = 0
         t_max = TAU * 2
 
-        original_freq = 4
+        # 10 samples per second
+        sample_frequency = 5
 
-        # original freq sampling rate attending to Nyquist
-        of_sampling_rate = original_freq * 2 + 1
+        # total number of samples
+        n_samples = 10
+
+        duration = n_samples // sample_frequency
+
+        analysis_frequencies = [n / duration for n in range(n_samples)]
+        print(analysis_frequencies[:5])
+
+        # let's just take one AF as an example
+        original_freq = analysis_frequencies[2]
 
         # this tracker will move phase: from 0 to PI/2
         vt = ValueTracker(0)
@@ -607,12 +616,14 @@ class IntroducePhaseProblem(MovingCameraScene):
         self.play(vt.animate.set_value(PI / 2))
         self.play(vt.animate.set_value(PI))
 
-        af_matrix = get_analysis_frequency_matrix(of_sampling_rate, t_max=t_max)
+        af_matrix = get_analysis_frequency_matrix(
+            n_samples, duration=duration, t_max=t_max
+        )
 
         sampled_signal = np.array(
             [
                 get_cosine_func(freq=original_freq)(v)
-                for v in np.linspace(t_min, t_max, num=of_sampling_rate, endpoint=False)
+                for v in np.linspace(t_min, t_max, num=n_samples, endpoint=False)
             ]
         ).reshape(-1, 1)
         mt = apply_matrix_transform(sampled_signal, af_matrix)
@@ -622,12 +633,13 @@ class IntroducePhaseProblem(MovingCameraScene):
         print(mt)
 
         self.play(*[FadeOut(mob) for mob in self.mobjects])
+        rect_scale = 0.8
         rects = VGroup(
             *[
                 VGroup(
-                    Rectangle(color=REDUCIBLE_VIOLET, width=0.3, height=f).set_fill(
-                        REDUCIBLE_VIOLET, opacity=1
-                    ),
+                    Rectangle(
+                        color=REDUCIBLE_VIOLET, width=0.3, height=f * rect_scale
+                    ).set_fill(REDUCIBLE_VIOLET, opacity=1),
                     Text(str(i), font=REDUCIBLE_MONO).scale(0.4),
                 ).arrange(DOWN)
                 for i, f in enumerate(mt.flatten())

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -586,15 +586,15 @@ class IntroducePhaseProblem(MovingCameraScene):
         frame = self.camera.frame.save_state()
         self.try_sine_wave()
 
-        # self.play(*[FadeOut(mob) for mob in self.mobjects])
-        # self.play(Restore(frame))
+        self.play(*[FadeOut(mob) for mob in self.mobjects])
+        self.play(Restore(frame))
 
-        # self.test_cases_again()
+        self.test_cases_again()
 
     def try_sine_wave(self):
         frame = self.camera.frame
         t_min = 0
-        t_max = TAU
+        t_max = 2 * PI
 
         original_freq = 2
 
@@ -630,13 +630,6 @@ class IntroducePhaseProblem(MovingCameraScene):
                 phase=vt_phase.get_value(),
                 b=vt_b.get_value(),
             )
-
-            sampled_signal = np.array(
-                [
-                    signal_function(v)
-                    for v in np.linspace(t_min, t_max, num=n_samples, endpoint=False)
-                ]
-            ).reshape(-1, 1)
 
             rects = get_fourier_rects_from_custom_matrix(
                 signal_function, af_matrix, n_samples=n_samples, t_max=t_max
@@ -758,13 +751,13 @@ class IntroducePhaseProblem(MovingCameraScene):
     def test_cases_again(self):
         frame = self.camera.frame
         t_min = 0
-        t_max = TAU * 2
+        t_max = 2 * PI
 
         # samples per second
-        sample_frequency = 16
+        n_samples = 16
 
         # total number of samples
-        n_samples = sample_frequency
+        sample_frequency = n_samples
 
         analysis_frequencies = [
             sample_frequency * m / n_samples for m in range(n_samples)
@@ -830,9 +823,7 @@ class IntroducePhaseProblem(MovingCameraScene):
             return changing_signal.scale(0.6).shift(UP)
 
         af_matrix = get_analysis_frequency_matrix(
-            N=n_samples,
-            sample_rate=sample_frequency,
-            t_max=t_max,
+            N=n_samples, sample_rate=sample_frequency, t_max=t_max
         )
 
         def updating_transform_redraw():
@@ -842,13 +833,6 @@ class IntroducePhaseProblem(MovingCameraScene):
                 phase=vt_phase.get_value(),
                 b=vt_b.get_value(),
             )
-
-            sampled_signal = np.array(
-                [
-                    signal_function(v)
-                    for v in np.linspace(t_min, t_max, num=n_samples, endpoint=False)
-                ]
-            ).reshape(-1, 1)
 
             rects = get_fourier_rects_from_custom_matrix(
                 signal_function, af_matrix, n_samples=n_samples, t_max=t_max

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1053,16 +1053,6 @@ class SolvingPhaseProblem(MovingCameraScene):
 
         original_frequency = analysis_frequencies[4]
 
-        og_t = Text(
-            f"Original signal, ƒ = {original_frequency:.2f} Hz", font=REDUCIBLE_MONO
-        ).scale(0.6)
-        af_sine_t = Text(f"Analysis frequency, sin(x)", font=REDUCIBLE_MONO).scale(0.6)
-        af_cos_t = Text(f"Analysis frequency, cos(x)", font=REDUCIBLE_MONO).scale(0.6)
-        og_t = Text(f"", font=REDUCIBLE_MONO).scale(0.6)
-        og_t = Text(
-            f"Original signal, ƒ = {original_frequency:.2f} Hz", font=REDUCIBLE_MONO
-        ).scale(0.6)
-
         # just an array of 5 dots to position the sine waves
         positions = (
             VGroup(*[Dot() for i in range(5)])
@@ -1141,10 +1131,46 @@ class SolvingPhaseProblem(MovingCameraScene):
         sin_prod_mob = always_redraw(changing_sin_prod)
         cos_prod_mob = always_redraw(changing_cos_prod)
 
+        og_t = (
+            Text(
+                f"x[n], ƒ = {original_frequency:.2f} Hz",
+                font=REDUCIBLE_FONT,
+                weight=BOLD,
+            )
+            .scale(0.4)
+            .next_to(og_signal_mob, LEFT)
+        )
+        af_sine_t = (
+            Text(f"sin(x)", font=REDUCIBLE_FONT, weight=BOLD)
+            .scale(0.4)
+            .next_to(sin_af_vg, LEFT)
+        )
+        af_cos_t = (
+            Text(f"cos(x)", font=REDUCIBLE_FONT, weight=BOLD)
+            .scale(0.4)
+            .next_to(cos_af_vg, LEFT)
+        )
+        sin_prod_t = (
+            Text(f"x[n] · sin(x)", font=REDUCIBLE_FONT, weight=BOLD)
+            .scale(0.4)
+            .next_to(sin_prod_mob, LEFT)
+        )
+        cos_prod_t = (
+            Text(f"x[n] · cos(x)", font=REDUCIBLE_FONT, weight=BOLD)
+            .scale(0.4)
+            .next_to(cos_prod_mob, LEFT)
+        )
+
         self.play(Write(og_signal_mob))
         self.play(Write(cos_af_vg))
         self.play(Write(cos_prod_mob))
         self.play(Write(sin_af_vg))
         self.play(Write(sin_prod_mob))
+
+        self.play(
+            LaggedStartMap(
+                FadeIn, VGroup(*[og_t, af_sine_t, af_cos_t, sin_prod_t, cos_prod_t])
+            )
+        )
 
         self.play(vt_phase.animate.set_value(8 * 2 * PI), run_time=15)

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -912,3 +912,8 @@ class IntroducePhaseProblem(MovingCameraScene):
         self.play(
             vt_phase.animate.set_value(20 * PI / 2), run_time=10, rate_func=linear
         )
+
+
+class SolvingPhaseProblem(MovingCameraScene):
+    def construct(self):
+        frame = self.camera.frame

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -875,12 +875,12 @@ class IntroducePhaseProblem(MovingCameraScene):
 
 class SolvingPhaseProblem(MovingCameraScene):
     def construct(self):
-        # frame = self.camera.frame.save_state()
+        frame = self.camera.frame.save_state()
 
-        # self.hacky_sine_waves()
+        self.hacky_sine_waves()
 
-        # self.play(*[FadeOut(mob) for mob in self.mobjects])
-        # self.play(Restore(frame))
+        self.play(*[FadeOut(mob) for mob in self.mobjects])
+        self.play(Restore(frame))
 
         self.capture_sine_and_cosine_transforms()
 
@@ -1167,4 +1167,8 @@ class SolvingPhaseProblem(MovingCameraScene):
         self.play(FadeIn(cos_dot_prod))
         self.wait()
 
-        self.play(vt_phase.animate.set_value(4 * 2 * PI), run_time=15)
+        self.play(
+            vt_phase.animate.set_value(4 * 2 * PI),
+            run_time=25,
+            rate_func=rate_functions.ease_in_out_sine,
+        )

--- a/DFT/jesus_dft.py
+++ b/DFT/jesus_dft.py
@@ -1245,16 +1245,32 @@ class SolvingPhaseProblem(MovingCameraScene):
         cos_dot_prod_new = always_redraw(get_dot_prod_cos_bar_new)
 
         self.play(FadeIn(cos_dot_prod_new))
+        self.play(FadeOut(cos_dot_prod_mob))
 
         number_plane = (
             NumberPlane(
                 x_length=5,
                 y_length=5,
-                x_range=[-3, 3],
-                y_range=[-3, 3],
+                x_range=[-2, 2],
+                y_range=[-2, 2],
                 background_line_style={"stroke_color": REDUCIBLE_VIOLET},
             )
             .set_opacity(0.7)
             .next_to(cos_dot_prod_new, RIGHT, buff=1)
         )
-        self.play(Write(number_plane))
+
+        def redraw_arc():
+            radius = Line(number_plane.c2p(0, 0), number_plane.c2p(1, 0)).width
+            np_center = number_plane.c2p(0, 0)
+            arc_center = (np_center[0], np_center[1], 0)
+            return (
+                Arc(radius, angle=vt_phase.get_value())
+                .move_arc_center_to(arc_center)
+                .set_color(REDUCIBLE_YELLOW)
+            )
+
+        arc = always_redraw(redraw_arc)
+
+        self.play(Write(number_plane), vt_phase.animate.set_value(0))
+        self.play(FadeIn(arc))
+        self.play(vt_phase.animate.set_value(2 * PI), run_time=10)

--- a/common/classes.py
+++ b/common/classes.py
@@ -486,3 +486,18 @@ class RCircularNode(VGroup):
             self.text.scale_to_fit_height(self.circle.height)
 
         super().__init__(self.circle, self.text, **kwargs)
+
+
+class LabeledDot(VGroup):
+    def __init__(self, n=3, color=REDUCIBLE_YELLOW, label_scale=1, **kwargs):
+        self.dot = Dot(radius=DEFAULT_DOT_RADIUS * 2, color=color)
+
+        self.text = (
+            Text(str(n), font=REDUCIBLE_MONO, weight=BOLD)
+            .set_stroke(BLACK, width=3, background=True)
+            .move_to(self.dot)
+        )
+        self.text.scale_to_fit_height(self.dot.height - (self.dot.height * 0.4))
+        self.text.scale(label_scale)
+
+        super().__init__(self.dot, self.text, **kwargs)

--- a/common/classes.py
+++ b/common/classes.py
@@ -368,8 +368,8 @@ class ReducibleBarChart(BarChart):
 
         super().__init__(
             values,
-            height=height,
-            width=width,
+            # height=height,
+            # width=width,
             n_ticks=n_ticks,
             tick_width=tick_width,
             label_y_axis=label_y_axis,

--- a/common/classes.py
+++ b/common/classes.py
@@ -489,15 +489,18 @@ class RCircularNode(VGroup):
 
 
 class LabeledDot(VGroup):
-    def __init__(self, n=3, color=REDUCIBLE_YELLOW, label_scale=1, **kwargs):
+    def __init__(
+        self, n=3, color=REDUCIBLE_YELLOW, label_color=BLACK, label_scale=1, **kwargs
+    ):
         self.dot = Dot(radius=DEFAULT_DOT_RADIUS * 2, color=color)
 
         self.text = (
-            Text(str(n), font=REDUCIBLE_MONO, weight=BOLD)
-            .set_stroke(BLACK, width=3, background=True)
+            Text(str(n), font=REDUCIBLE_MONO)
+            .set_stroke(BLACK, width=4, background=True)
             .move_to(self.dot)
         )
         self.text.scale_to_fit_height(self.dot.height - (self.dot.height * 0.4))
         self.text.scale(label_scale)
+        self.text.set_color(label_color)
 
         super().__init__(self.dot, self.text, **kwargs)

--- a/common/functions.py
+++ b/common/functions.py
@@ -119,3 +119,8 @@ def matrix_to_mob(matrix: np.ndarray, h_buff=2.3, v_buff=1.3):
         h_buff=h_buff,
         v_buff=v_buff,
     ).scale(0.3)
+
+
+def focus_on(frame, mobject, buff=2):
+    """Returns a ready to play animation of the camera focusing on a given mobject"""
+    return frame.animate.set_width(mobject.width * buff).move_to(mobject)

--- a/common/functions.py
+++ b/common/functions.py
@@ -2,6 +2,7 @@
 File for various PNG and QOI Helper Functions
 """
 
+from typing import Iterable
 from manim import *
 
 from reducible_colors import *
@@ -121,12 +122,21 @@ def matrix_to_mob(matrix: np.ndarray, h_buff=2.3, v_buff=1.3):
     ).scale(0.3)
 
 
-def focus_on(frame, mobject, buff=1):
+def focus_on(frame, mobjects, buff=1):
     """Returns a ready to play animation of the camera focusing on a given mobject"""
-    mob_w = mobject.width
-    mob_h = mobject.height
+    if isinstance(mobjects, Iterable):
+        vmobject = VGroup(*mobjects)
+    elif isinstance(mobjects, Mobject) or isinstance(mobjects, VGroup):
+        vmobject = mobjects
+    else:
+        raise TypeError(
+            "Mobjects argument can either be a single mobject, a single VGroup or an iterable of mobjects (tuple, list, np.array...)"
+        )
+
+    mob_w = vmobject.width
+    mob_h = vmobject.height
 
     if mob_w >= mob_h:
-        return frame.animate.set_width(mobject.width + buff).move_to(mobject)
+        return frame.animate.set_width(vmobject.width + buff).move_to(vmobject)
     else:
-        return frame.animate.set_height(mobject.height + buff).move_to(mobject)
+        return frame.animate.set_height(vmobject.height + buff).move_to(vmobject)

--- a/common/functions.py
+++ b/common/functions.py
@@ -121,6 +121,12 @@ def matrix_to_mob(matrix: np.ndarray, h_buff=2.3, v_buff=1.3):
     ).scale(0.3)
 
 
-def focus_on(frame, mobject, buff=1.1):
+def focus_on(frame, mobject, buff=1):
     """Returns a ready to play animation of the camera focusing on a given mobject"""
-    return frame.animate.set_width(mobject.width * buff).move_to(mobject)
+    mob_w = mobject.width
+    mob_h = mobject.height
+
+    if mob_w >= mob_h:
+        return frame.animate.set_width(mobject.width + buff).move_to(mobject)
+    else:
+        return frame.animate.set_height(mobject.height + buff).move_to(mobject)

--- a/common/functions.py
+++ b/common/functions.py
@@ -121,6 +121,6 @@ def matrix_to_mob(matrix: np.ndarray, h_buff=2.3, v_buff=1.3):
     ).scale(0.3)
 
 
-def focus_on(frame, mobject, buff=2):
+def focus_on(frame, mobject, buff=1.1):
     """Returns a ready to play animation of the camera focusing on a given mobject"""
     return frame.animate.set_width(mobject.width * buff).move_to(mobject)


### PR DESCRIPTION
@nipunramk lemme know your thoughts!

# Script
> Now, some of you may be wondering, why are you only doing cosine waves? What about sine waves? And yeah, absolutely valid question – if we pass in a sine wave of some frequency <>, we should ideally get that frequency extracted out of the signal, right? So let’s try it – we’ll take a sampled points from our sine wave in exactly the same manner, pass it through our transform, and … hmm, that doesn’t seem right. It looks like all the frequency components are 0. And if we do some further digging, it turns out that the analysis frequency of <> cosine wave and this sine wave indeed have a dot product of 0. This is a big problem, it breaks a fundamental property of what we’re looking for in a fourier transform. Our test transform as currently constructed will be unable to extract frequency information from sine waves. Why does this happen?

> To understand why, we have to go back to our test cases – we tested changing amplitudes, we tested changing frequencies, and we also tested shifting the signals up and down. One other component of signals that we can change is the phase. What we expect to happen when we change the phase is that our frequency component strength should stay the same. After all, it’s the same frequency still present in the original signal, just shifted across time. But what happens with our test transform, is unfortunately, the frequency strength is impacted by the phase. The sine wave example is just a specific case of that when the phase is offset by 90 degrees. So, unfortunately, we have to go back to the drawing board. What can we do to handle this phase problem?




# Scene


https://user-images.githubusercontent.com/50735312/207182451-5c8e6c95-0c1a-4078-925b-b9d73573f448.mp4




